### PR TITLE
change IRIs with plural unit of measure to singular

### DIFF
--- a/Data/uomReferenceData-starter-set.ttl
+++ b/Data/uomReferenceData-starter-set.ttl
@@ -1636,13 +1636,13 @@
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_candela> <https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor> "1.0"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_candela> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_luminous_flux> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_candela> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_luminous_intensity> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#altLabel> "cases per 1000 individuals per year" .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://qudt.org/vocab/unit/CASES-PER-1000I-YR> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#definition> "from QUDT: The typical expression of morbidity rate, expressed as cases per 1000 individuals, per year." .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#prefLabel> "case per 1000 individuals per year" .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_cases_per_1000_individuals_per_year> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_rate_of_morbidity> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#altLabel> "cases per 1000 individuals per year" .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://qudt.org/vocab/unit/CASES-PER-1000I-YR> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#definition> "from QUDT: The typical expression of morbidity rate, expressed as cases per 1000 individuals, per year." .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <http://www.w3.org/2004/02/skos/core#prefLabel> "case per 1000 individuals per year" .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_case_per_1000_individuals_per_year> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_rate_of_morbidity> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_centimeter> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_centimeter> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "http://en.wikipedia.org/wiki/Centimetre?oldid=494931891"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_centimeter> <http://www.w3.org/2004/02/skos/core#altLabel> "centimeters" .
@@ -1669,7 +1669,7 @@
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <http://www.w3.org/2004/02/skos/core#altLabel> "count_per_minute" .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <http://www.w3.org/2004/02/skos/core#definition> "Count per minute." .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <http://www.w3.org/2004/02/skos/core#prefLabel> "counts_per_minute" .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <http://www.w3.org/2004/02/skos/core#prefLabel> "count_per_minute" .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <http://www.w3.org/2004/02/skos/core#scopeNote> "1 count_per_minute = 0.0166666666666 x number per second" .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor> "0.0166666666666"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_count_per_minute> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_count_per_minute_duration> .
@@ -1715,16 +1715,16 @@
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_day_per_week> <http://www.w3.org/2004/02/skos/core#prefLabel> "day per week" .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_day_per_week> <https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor> "0.14285714"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_day_per_week> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_labor_consumption_rate> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://en.wikipedia.org/wiki/Mortality_rate"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#altLabel> "deaths per million individuals per year" .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://qudt.org/vocab/unit/DEATHS-PER-1000000I-YR> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://qudt.org/vocab/unit/DEATHS-PER-MegaINDIV-YR> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#definition> "from QUDT: The expression of mortality rate, expressed as deaths per Million individuals, per year." .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#prefLabel> "deaths per million individuals per year" .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#scopeNote> "1 deaths per million individuals per year = 0.000001 x per second" .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor> "0.000001"^^<http://www.w3.org/2001/XMLSchema#decimal> .
-<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_deaths_per_million_individuals_per_year> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_rate_of_mortality> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://en.wikipedia.org/wiki/Mortality_rate"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#altLabel> "deaths per million individuals per year" .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://qudt.org/vocab/unit/DEATHS-PER-1000000I-YR> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#closeMatch> <http://qudt.org/vocab/unit/DEATHS-PER-MegaINDIV-YR> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#definition> "from QUDT: The expression of mortality rate, expressed as deaths per Million individuals, per year." .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#prefLabel> "deaths per million individuals per year" .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <http://www.w3.org/2004/02/skos/core#scopeNote> "1 deaths per million individuals per year = 0.000001 x per second" .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <https://w3id.org/semanticarts/ns/ontology/gist/conversionFactor> "0.000001"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_death_per_million_individuals_per_year> <https://w3id.org/semanticarts/ns/ontology/gist/isMemberOf> <https://w3id.org/semanticarts/ns/data/gist/_UnitGroup_rate_of_mortality> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_decibel> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/semanticarts/ns/ontology/gist/UnitOfMeasure> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_decibel> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "http://en.wikipedia.org/wiki/Decibel?oldid=495380648"^^<http://www.w3.org/2001/XMLSchema#anyURI> .
 <https://w3id.org/semanticarts/ns/data/gist/_UnitOfMeasure_decibel> <http://www.w3.org/2004/02/skos/core#altLabel> "decibels" .

--- a/Data/uomReferenceData.ttl
+++ b/Data/uomReferenceData.ttl
@@ -12444,13 +12444,13 @@ gistd:_UnitOfMeasure_carat skos:altLabel "carats" .
 gistd:_UnitOfMeasure_carat skos:closeMatch <http://qudt.org/vocab/unit/CARAT> .
 gistd:_UnitOfMeasure_carat skos:prefLabel "carat" .
 gistd:_UnitOfMeasure_carat skos:scopeNote "1 carat = 0.0002 x kilogram" .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year gist:isMemberOf gistd:_UnitGroup_rate_of_morbidity .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year rdfs:seeAlso "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"^^xsd:anyURI .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year skos:altLabel "cases per 1000 individuals per year" .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/CASES-PER-1000I-YR> .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year skos:definition "from QUDT: The typical expression of morbidity rate, expressed as cases per 1000 individuals, per year." .
-gistd:_UnitOfMeasure_cases_per_1000_individuals_per_year skos:prefLabel "case per 1000 individuals per year" .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year gist:isMemberOf gistd:_UnitGroup_rate_of_morbidity .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year rdfs:seeAlso "https://en.wikipedia.org/wiki/Incidence_(epidemiology)"^^xsd:anyURI .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year skos:altLabel "cases per 1000 individuals per year" .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/CASES-PER-1000I-YR> .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year skos:definition "from QUDT: The typical expression of morbidity rate, expressed as cases per 1000 individuals, per year." .
+gistd:_UnitOfMeasure_case_per_1000_individuals_per_year skos:prefLabel "case per 1000 individuals per year" .
 gistd:_UnitOfMeasure_centibar gist:conversionFactor "1000.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_centibar gist:isMemberOf gistd:_UnitGroup_force_per_area .
 gistd:_UnitOfMeasure_centibar rdf:type gist:UnitOfMeasure .
@@ -12792,13 +12792,13 @@ gistd:_UnitOfMeasure_count_per_second_steradian skos:altLabel "counts per second
 gistd:_UnitOfMeasure_count_per_second_steradian skos:definition "Count per second per steradian. For example, to measure photon flux per solid angle." .
 gistd:_UnitOfMeasure_count_per_second_steradian skos:prefLabel "count per second steradian" .
 gistd:_UnitOfMeasure_count_per_second_steradian skos:scopeNote "1 count per second steradian = 1 x count per second steradian " .
-gistd:_UnitOfMeasure_counts_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_counts_per_second gist:isMemberOf gistd:_UnitGroup_number_per_duration .
-gistd:_UnitOfMeasure_counts_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_counts_per_second skos:altLabel "counts per second" .
-gistd:_UnitOfMeasure_counts_per_second skos:closeMatch <http://qudt.org/vocab/unit/NUM-PER-SEC> .
-gistd:_UnitOfMeasure_counts_per_second skos:prefLabel "counts per second" .
-gistd:_UnitOfMeasure_counts_per_second skos:scopeNote "1 counts per second = 1.0 x per second" .
+gistd:_UnitOfMeasure_count_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_count_per_second gist:isMemberOf gistd:_UnitGroup_number_per_duration .
+gistd:_UnitOfMeasure_count_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_count_per_second skos:altLabel "counts per second" .
+gistd:_UnitOfMeasure_count_per_second skos:closeMatch <http://qudt.org/vocab/unit/NUM-PER-SEC> .
+gistd:_UnitOfMeasure_count_per_second skos:prefLabel "counts per second" .
+gistd:_UnitOfMeasure_count_per_second skos:scopeNote "1 counts per second = 1.0 x per second" .
 gistd:_UnitOfMeasure_cubic_angstrom gist:conversionFactor "0.0000000000000000000000000000000000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_cubic_angstrom gist:isMemberOf gistd:_UnitGroup_volume .
 gistd:_UnitOfMeasure_cubic_angstrom rdf:type gist:UnitOfMeasure .
@@ -13159,27 +13159,27 @@ gistd:_UnitOfMeasure_cubic_meter_per_square_second skos:altLabel "cubic meters p
 gistd:_UnitOfMeasure_cubic_meter_per_square_second skos:closeMatch <http://qudt.org/vocab/unit/M3-PER-SEC2> .
 gistd:_UnitOfMeasure_cubic_meter_per_square_second skos:prefLabel "cubic meter per square second" .
 gistd:_UnitOfMeasure_cubic_meter_per_square_second skos:scopeNote "1 cubic meter per square second = 1.0 x meterCubed per secondSquared" .
-gistd:_UnitOfMeasure_cubic_micrometer_microns gist:conversionFactor "0.000000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_cubic_micrometer_microns gist:isMemberOf gistd:_UnitGroup_volume .
-gistd:_UnitOfMeasure_cubic_micrometer_microns rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_cubic_micrometer_microns skos:altLabel "cubic micrometers (microns)" .
-gistd:_UnitOfMeasure_cubic_micrometer_microns skos:closeMatch <http://qudt.org/vocab/unit/MicroM3> .
-gistd:_UnitOfMeasure_cubic_micrometer_microns skos:prefLabel "cubic micrometers (microns)" .
-gistd:_UnitOfMeasure_cubic_micrometer_microns skos:scopeNote "1 cubic micrometers (microns) = 0.000000000000000001 x meterCubed" .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter gist:conversionFactor "0.000000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_ratio_of_volumes .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter skos:altLabel "cubic microns per cubic meter" .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/MicroM3-PER-M3> .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter skos:prefLabel "cubic microns per cubic meter" .
-gistd:_UnitOfMeasure_cubic_microns_per_cubic_meter skos:scopeNote "1 cubic microns per cubic meter = 0.000000000000000001 x meterCubed per meterCubed" .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter gist:isMemberOf gistd:_UnitGroup_ratio_of_volumes .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter skos:altLabel "cubic microns per milliliter" .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/MicroM3-PER-MilliL> .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter skos:prefLabel "cubic microns per milliliter" .
-gistd:_UnitOfMeasure_cubic_microns_per_milliliter skos:scopeNote "1 cubic microns per milliliter = 0.000000000001 x meterCubed per meterCubed" .
+gistd:_UnitOfMeasure_cubic_micrometer_micron gist:conversionFactor "0.000000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_cubic_micrometer_micron gist:isMemberOf gistd:_UnitGroup_volume .
+gistd:_UnitOfMeasure_cubic_micrometer_micron rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_cubic_micrometer_micron skos:altLabel "cubic micrometers (microns)" .
+gistd:_UnitOfMeasure_cubic_micrometer_micron skos:closeMatch <http://qudt.org/vocab/unit/MicroM3> .
+gistd:_UnitOfMeasure_cubic_micrometer_micron skos:prefLabel "cubic micrometers (microns)" .
+gistd:_UnitOfMeasure_cubic_micrometer_micron skos:scopeNote "1 cubic micrometers (microns) = 0.000000000000000001 x meterCubed" .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter gist:conversionFactor "0.000000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_ratio_of_volumes .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter skos:altLabel "cubic microns per cubic meter" .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/MicroM3-PER-M3> .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter skos:prefLabel "cubic microns per cubic meter" .
+gistd:_UnitOfMeasure_cubic_micron_per_cubic_meter skos:scopeNote "1 cubic microns per cubic meter = 0.000000000000000001 x meterCubed per meterCubed" .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter gist:isMemberOf gistd:_UnitGroup_ratio_of_volumes .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter skos:altLabel "cubic microns per milliliter" .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/MicroM3-PER-MilliL> .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter skos:prefLabel "cubic microns per milliliter" .
+gistd:_UnitOfMeasure_cubic_micron_per_milliliter skos:scopeNote "1 cubic microns per milliliter = 0.000000000001 x meterCubed per meterCubed" .
 gistd:_UnitOfMeasure_cubic_mile gist:conversionFactor "4168181830.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_cubic_mile gist:isMemberOf gistd:_UnitGroup_volume .
 gistd:_UnitOfMeasure_cubic_mile rdf:type gist:UnitOfMeasure .
@@ -13290,24 +13290,24 @@ gistd:_UnitOfMeasure_day_per_week rdf:type gist:UnitOfMeasure .
 gistd:_UnitOfMeasure_day_per_week skos:altLabel "days per week" .
 gistd:_UnitOfMeasure_day_per_week skos:definition "day_per_week." .
 gistd:_UnitOfMeasure_day_per_week skos:prefLabel "day per week" .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year gist:isMemberOf gistd:_UnitGroup_rate_of_mortality .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year rdfs:seeAlso "https://en.wikipedia.org/wiki/Mortality_rate"^^xsd:anyURI .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year skos:altLabel "deaths per 1000 individuals per year" .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-1000I-YR> .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-KiloINDIV-YR> .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year skos:definition "from QUDT: The typical expression of mortality rate, expressed as deaths per 1000 individuals, per year." .
-gistd:_UnitOfMeasure_deaths_per_1000_individuals_per_year skos:prefLabel "deaths per 1000 individuals per year" .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year gist:isMemberOf gistd:_UnitGroup_rate_of_mortality .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year rdfs:seeAlso "https://en.wikipedia.org/wiki/Mortality_rate"^^xsd:anyURI .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year skos:altLabel "deaths per million individuals per year" .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-1000000I-YR> .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-MegaINDIV-YR> .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year skos:definition "from QUDT: The expression of mortality rate, expressed as deaths per Million individuals, per year." .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year skos:prefLabel "deaths per million individuals per year" .
-gistd:_UnitOfMeasure_deaths_per_million_individuals_per_year skos:scopeNote "1 deaths per million individuals per year = 0.000001 x per second" .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year gist:isMemberOf gistd:_UnitGroup_rate_of_mortality .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year rdfs:seeAlso "https://en.wikipedia.org/wiki/Mortality_rate"^^xsd:anyURI .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year skos:altLabel "deaths per 1000 individuals per year" .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-1000I-YR> .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-KiloINDIV-YR> .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year skos:definition "from QUDT: The typical expression of mortality rate, expressed as deaths per 1000 individuals, per year." .
+gistd:_UnitOfMeasure_death_per_1000_individuals_per_year skos:prefLabel "deaths per 1000 individuals per year" .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year gist:isMemberOf gistd:_UnitGroup_rate_of_mortality .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year rdfs:seeAlso "https://en.wikipedia.org/wiki/Mortality_rate"^^xsd:anyURI .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year skos:altLabel "deaths per million individuals per year" .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-1000000I-YR> .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEATHS-PER-MegaINDIV-YR> .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year skos:definition "from QUDT: The expression of mortality rate, expressed as deaths per Million individuals, per year." .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year skos:prefLabel "deaths per million individuals per year" .
+gistd:_UnitOfMeasure_death_per_million_individuals_per_year skos:scopeNote "1 deaths per million individuals per year = 0.000001 x per second" .
 gistd:_UnitOfMeasure_debye gist:conversionFactor "0.00000000000000000000000000000333564"^^xsd:decimal .
 gistd:_UnitOfMeasure_debye gist:isMemberOf gistd:_UnitGroup_electric_dipole_moment .
 gistd:_UnitOfMeasure_debye rdf:type gist:UnitOfMeasure .
@@ -13377,13 +13377,13 @@ gistd:_UnitOfMeasure_decibar skos:altLabel "decibars" .
 gistd:_UnitOfMeasure_decibar skos:closeMatch <http://qudt.org/vocab/unit/DeciBAR> .
 gistd:_UnitOfMeasure_decibar skos:prefLabel "decibar" .
 gistd:_UnitOfMeasure_decibar skos:scopeNote "1 decibar = 10000.0 x kilogram per meter secondSquared" .
-gistd:_UnitOfMeasure_decibars_per_year gist:conversionFactor "0.00031688"^^xsd:decimal .
-gistd:_UnitOfMeasure_decibars_per_year gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
-gistd:_UnitOfMeasure_decibars_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_decibars_per_year skos:altLabel "decibars per year" .
-gistd:_UnitOfMeasure_decibars_per_year skos:closeMatch <http://qudt.org/vocab/unit/DeciBAR-PER-YR> .
-gistd:_UnitOfMeasure_decibars_per_year skos:prefLabel "decibars per year" .
-gistd:_UnitOfMeasure_decibars_per_year skos:scopeNote "1 decibars per year = 0.00031688 x kilogram per meter secondCubed" .
+gistd:_UnitOfMeasure_decibar_per_year gist:conversionFactor "0.00031688"^^xsd:decimal .
+gistd:_UnitOfMeasure_decibar_per_year gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
+gistd:_UnitOfMeasure_decibar_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_decibar_per_year skos:altLabel "decibars per year" .
+gistd:_UnitOfMeasure_decibar_per_year skos:closeMatch <http://qudt.org/vocab/unit/DeciBAR-PER-YR> .
+gistd:_UnitOfMeasure_decibar_per_year skos:prefLabel "decibars per year" .
+gistd:_UnitOfMeasure_decibar_per_year skos:scopeNote "1 decibars per year = 0.00031688 x kilogram per meter secondCubed" .
 gistd:_UnitOfMeasure_decibel gist:isMemberOf gistd:_UnitGroup_sound_power_level .
 gistd:_UnitOfMeasure_decibel rdf:type gist:UnitOfMeasure .
 gistd:_UnitOfMeasure_decibel rdfs:seeAlso "http://en.wikipedia.org/wiki/Decibel?oldid=495380648"^^xsd:anyURI .
@@ -13462,21 +13462,21 @@ gistd:_UnitOfMeasure_decinewton_meter skos:closeMatch <http://qudt.org/vocab/uni
 gistd:_UnitOfMeasure_decinewton_meter skos:definition "from QUDT: 0.1-fold of the product of the derived SI unit joule and the SI base unit metre" .
 gistd:_UnitOfMeasure_decinewton_meter skos:prefLabel "decinewton meter" .
 gistd:_UnitOfMeasure_decinewton_meter skos:scopeNote "1 decinewton meter = 0.1 x kilogram meterSquared per secondSquared" .
-gistd:_UnitOfMeasure_decisiemens gist:conversionFactor "0.1"^^xsd:decimal .
-gistd:_UnitOfMeasure_decisiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_decisiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_decisiemens skos:altLabel "decisiemens" .
-gistd:_UnitOfMeasure_decisiemens skos:closeMatch <http://qudt.org/vocab/unit/DeciS> .
-gistd:_UnitOfMeasure_decisiemens skos:prefLabel "decisiemens" .
-gistd:_UnitOfMeasure_decisiemens skos:scopeNote "1 decisiemens = 0.1 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_decisiemens_per_meter gist:conversionFactor "0.1"^^xsd:decimal .
-gistd:_UnitOfMeasure_decisiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_decisiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_decisiemens_per_meter skos:altLabel "decisiemens per meter" .
-gistd:_UnitOfMeasure_decisiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/DeciS-PER-M> .
-gistd:_UnitOfMeasure_decisiemens_per_meter skos:definition "from QUDT: Decisiemens per metre." .
-gistd:_UnitOfMeasure_decisiemens_per_meter skos:prefLabel "decisiemens per meter" .
-gistd:_UnitOfMeasure_decisiemens_per_meter skos:scopeNote "1 decisiemens per meter = 0.1 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_decisiemen gist:conversionFactor "0.1"^^xsd:decimal .
+gistd:_UnitOfMeasure_decisiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_decisiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_decisiemen skos:altLabel "decisiemens" .
+gistd:_UnitOfMeasure_decisiemen skos:closeMatch <http://qudt.org/vocab/unit/DeciS> .
+gistd:_UnitOfMeasure_decisiemen skos:prefLabel "decisiemens" .
+gistd:_UnitOfMeasure_decisiemen skos:scopeNote "1 decisiemens = 0.1 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_decisiemen_per_meter gist:conversionFactor "0.1"^^xsd:decimal .
+gistd:_UnitOfMeasure_decisiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_decisiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_decisiemen_per_meter skos:altLabel "decisiemens per meter" .
+gistd:_UnitOfMeasure_decisiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/DeciS-PER-M> .
+gistd:_UnitOfMeasure_decisiemen_per_meter skos:definition "from QUDT: Decisiemens per metre." .
+gistd:_UnitOfMeasure_decisiemen_per_meter skos:prefLabel "decisiemens per meter" .
+gistd:_UnitOfMeasure_decisiemen_per_meter skos:scopeNote "1 decisiemens per meter = 0.1 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_decitonne gist:conversionFactor "100.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_decitonne gist:isMemberOf gistd:_UnitGroup_mass .
 gistd:_UnitOfMeasure_decitonne rdf:type gist:UnitOfMeasure .
@@ -13724,27 +13724,27 @@ gistd:_UnitOfMeasure_degree_twaddell skos:closeMatch <http://qudt.org/vocab/unit
 gistd:_UnitOfMeasure_degree_twaddell skos:definition "from QUDT: unit of the density of fluids, which are heavier than water" .
 gistd:_UnitOfMeasure_degree_twaddell skos:prefLabel "degree twaddell" .
 gistd:_UnitOfMeasure_degree_twaddell skos:scopeNote "1 degree twaddell = 0.0 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter gist:isMemberOf gistd:_UnitGroup_temperature_gradient .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter skos:altLabel "degrees celsius per meter" .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter skos:closeMatch <http://qudt.org/vocab/unit/DEG_C-PER-M> .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter skos:prefLabel "degrees celsius per meter" .
-gistd:_UnitOfMeasure_degrees_celsius_per_meter skos:scopeNote "1 degrees celsius per meter = 1.0 x kelvin per meter" .
-gistd:_UnitOfMeasure_degrees_celsius_per_year gist:conversionFactor "0.0000000316880878140289"^^xsd:decimal .
-gistd:_UnitOfMeasure_degrees_celsius_per_year gist:isMemberOf gistd:_UnitGroup_temperature_per_time .
-gistd:_UnitOfMeasure_degrees_celsius_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_degrees_celsius_per_year skos:altLabel "degrees celsius per year" .
-gistd:_UnitOfMeasure_degrees_celsius_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEG_C-PER-YR> .
-gistd:_UnitOfMeasure_degrees_celsius_per_year skos:prefLabel "degrees celsius per year" .
-gistd:_UnitOfMeasure_degrees_celsius_per_year skos:scopeNote "1 degrees celsius per year = 0.0000000316880878140289 x kelvin per second" .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter gist:isMemberOf gistd:_UnitGroup_temperature_gradient .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter skos:altLabel "degrees kelvin per meter" .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter skos:closeMatch <http://qudt.org/vocab/unit/K-PER-M> .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter skos:prefLabel "degrees kelvin per meter" .
-gistd:_UnitOfMeasure_degrees_kelvin_per_meter skos:scopeNote "1 degrees kelvin per meter = 1.0 x kelvin per meter" .
+gistd:_UnitOfMeasure_degree_celsius_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_degree_celsius_per_meter gist:isMemberOf gistd:_UnitGroup_temperature_gradient .
+gistd:_UnitOfMeasure_degree_celsius_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_degree_celsius_per_meter skos:altLabel "degrees celsius per meter" .
+gistd:_UnitOfMeasure_degree_celsius_per_meter skos:closeMatch <http://qudt.org/vocab/unit/DEG_C-PER-M> .
+gistd:_UnitOfMeasure_degree_celsius_per_meter skos:prefLabel "degrees celsius per meter" .
+gistd:_UnitOfMeasure_degree_celsius_per_meter skos:scopeNote "1 degrees celsius per meter = 1.0 x kelvin per meter" .
+gistd:_UnitOfMeasure_degree_celsius_per_year gist:conversionFactor "0.0000000316880878140289"^^xsd:decimal .
+gistd:_UnitOfMeasure_degree_celsius_per_year gist:isMemberOf gistd:_UnitGroup_temperature_per_time .
+gistd:_UnitOfMeasure_degree_celsius_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_degree_celsius_per_year skos:altLabel "degrees celsius per year" .
+gistd:_UnitOfMeasure_degree_celsius_per_year skos:closeMatch <http://qudt.org/vocab/unit/DEG_C-PER-YR> .
+gistd:_UnitOfMeasure_degree_celsius_per_year skos:prefLabel "degrees celsius per year" .
+gistd:_UnitOfMeasure_degree_celsius_per_year skos:scopeNote "1 degrees celsius per year = 0.0000000316880878140289 x kelvin per second" .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter gist:isMemberOf gistd:_UnitGroup_temperature_gradient .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter skos:altLabel "degrees kelvin per meter" .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter skos:closeMatch <http://qudt.org/vocab/unit/K-PER-M> .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter skos:prefLabel "degrees kelvin per meter" .
+gistd:_UnitOfMeasure_degree_kelvin_per_meter skos:scopeNote "1 degrees kelvin per meter = 1.0 x kelvin per meter" .
 gistd:_UnitOfMeasure_denier gist:conversionFactor "0.00000011"^^xsd:decimal .
 gistd:_UnitOfMeasure_denier gist:isMemberOf gistd:_UnitGroup_mass_per_distance .
 gistd:_UnitOfMeasure_denier rdf:type gist:UnitOfMeasure .
@@ -13762,14 +13762,14 @@ gistd:_UnitOfMeasure_diopter skos:altLabel "diopters" .
 gistd:_UnitOfMeasure_diopter skos:closeMatch <http://qudt.org/vocab/unit/DIOPTER> .
 gistd:_UnitOfMeasure_diopter skos:prefLabel "diopter" .
 gistd:_UnitOfMeasure_diopter skos:scopeNote "1 diopter = 1.0 x per meter" .
-gistd:_UnitOfMeasure_dots_per_inch gist:conversionFactor "39.37008"^^xsd:decimal .
-gistd:_UnitOfMeasure_dots_per_inch gist:isMemberOf gistd:_UnitGroup_number_per_distance .
-gistd:_UnitOfMeasure_dots_per_inch rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_dots_per_inch skos:altLabel "dots per inch" .
-gistd:_UnitOfMeasure_dots_per_inch skos:closeMatch <http://qudt.org/vocab/unit/DPI> .
-gistd:_UnitOfMeasure_dots_per_inch skos:definition "from QUDT: point density as amount of the picture base element divided by the unit inch according to the Anglo-American and the Imperial system of units" .
-gistd:_UnitOfMeasure_dots_per_inch skos:prefLabel "dots per inch" .
-gistd:_UnitOfMeasure_dots_per_inch skos:scopeNote "1 dots per inch = 39.37008 x per meter" .
+gistd:_UnitOfMeasure_dot_per_inch gist:conversionFactor "39.37008"^^xsd:decimal .
+gistd:_UnitOfMeasure_dot_per_inch gist:isMemberOf gistd:_UnitGroup_number_per_distance .
+gistd:_UnitOfMeasure_dot_per_inch rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_dot_per_inch skos:altLabel "dots per inch" .
+gistd:_UnitOfMeasure_dot_per_inch skos:closeMatch <http://qudt.org/vocab/unit/DPI> .
+gistd:_UnitOfMeasure_dot_per_inch skos:definition "from QUDT: point density as amount of the picture base element divided by the unit inch according to the Anglo-American and the Imperial system of units" .
+gistd:_UnitOfMeasure_dot_per_inch skos:prefLabel "dots per inch" .
+gistd:_UnitOfMeasure_dot_per_inch skos:scopeNote "1 dots per inch = 39.37008 x per meter" .
 gistd:_UnitOfMeasure_dozen gist:conversionFactor "12"^^xsd:decimal .
 gistd:_UnitOfMeasure_dozen gist:isMemberOf gistd:_UnitGroup_number_of_things .
 gistd:_UnitOfMeasure_dozen rdf:type gist:UnitOfMeasure .
@@ -14030,14 +14030,14 @@ gistd:_UnitOfMeasure_exbibyte rdfs:seeAlso "https://en.wikipedia.org/wiki/Byte#M
 gistd:_UnitOfMeasure_exbibyte skos:altLabel "exbibytes" .
 gistd:_UnitOfMeasure_exbibyte skos:closeMatch <http://qudt.org/vocab/unit/ExbiBYTE> .
 gistd:_UnitOfMeasure_exbibyte skos:prefLabel "exbibyte" .
-gistd:_UnitOfMeasure_failures_in_time gist:conversionFactor "0.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_failures_in_time gist:isMemberOf gistd:_UnitGroup_number_per_duration .
-gistd:_UnitOfMeasure_failures_in_time rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_failures_in_time skos:altLabel "failures in time" .
-gistd:_UnitOfMeasure_failures_in_time skos:closeMatch <http://qudt.org/vocab/unit/failures-in-time> .
-gistd:_UnitOfMeasure_failures_in_time skos:definition "from QUDT: unit of failure rate" .
-gistd:_UnitOfMeasure_failures_in_time skos:prefLabel "failures in time" .
-gistd:_UnitOfMeasure_failures_in_time skos:scopeNote "1 failures in time = 0.0 x per second" .
+gistd:_UnitOfMeasure_failure_in_time gist:conversionFactor "0.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_failure_in_time gist:isMemberOf gistd:_UnitGroup_number_per_duration .
+gistd:_UnitOfMeasure_failure_in_time rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_failure_in_time skos:altLabel "failures in time" .
+gistd:_UnitOfMeasure_failure_in_time skos:closeMatch <http://qudt.org/vocab/unit/failures-in-time> .
+gistd:_UnitOfMeasure_failure_in_time skos:definition "from QUDT: unit of failure rate" .
+gistd:_UnitOfMeasure_failure_in_time skos:prefLabel "failures in time" .
+gistd:_UnitOfMeasure_failure_in_time skos:scopeNote "1 failures in time = 0.0 x per second" .
 gistd:_UnitOfMeasure_farad gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_farad gist:isMemberOf gistd:_UnitGroup_capacitance .
 gistd:_UnitOfMeasure_farad rdf:type gist:UnitOfMeasure .
@@ -14094,20 +14094,20 @@ gistd:_UnitOfMeasure_femtogram skos:altLabel "femtograms" .
 gistd:_UnitOfMeasure_femtogram skos:closeMatch <http://qudt.org/vocab/unit/FemtoGM> .
 gistd:_UnitOfMeasure_femtogram skos:prefLabel "femtogram" .
 gistd:_UnitOfMeasure_femtogram skos:scopeNote "1 femtogram = 0.000000000000000001 x kilogram" .
-gistd:_UnitOfMeasure_femtograms_per_kilogram gist:conversionFactor "0.000000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_femtograms_per_kilogram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
-gistd:_UnitOfMeasure_femtograms_per_kilogram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_femtograms_per_kilogram skos:altLabel "femtograms per kilogram" .
-gistd:_UnitOfMeasure_femtograms_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/FemtoGM-PER-KiloGM> .
-gistd:_UnitOfMeasure_femtograms_per_kilogram skos:prefLabel "femtograms per kilogram" .
-gistd:_UnitOfMeasure_femtograms_per_kilogram skos:scopeNote "1 femtograms per kilogram = 0.000000000000000001 x kilogram per kilogram" .
-gistd:_UnitOfMeasure_femtograms_per_liter gist:conversionFactor "0.000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_femtograms_per_liter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_femtograms_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_femtograms_per_liter skos:altLabel "femtograms per liter" .
-gistd:_UnitOfMeasure_femtograms_per_liter skos:closeMatch <http://qudt.org/vocab/unit/FemtoGM-PER-L> .
-gistd:_UnitOfMeasure_femtograms_per_liter skos:prefLabel "femtograms per liter" .
-gistd:_UnitOfMeasure_femtograms_per_liter skos:scopeNote "1 femtograms per liter = 0.000000000000001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_femtogram_per_kilogram gist:conversionFactor "0.000000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_femtogram_per_kilogram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
+gistd:_UnitOfMeasure_femtogram_per_kilogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_femtogram_per_kilogram skos:altLabel "femtograms per kilogram" .
+gistd:_UnitOfMeasure_femtogram_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/FemtoGM-PER-KiloGM> .
+gistd:_UnitOfMeasure_femtogram_per_kilogram skos:prefLabel "femtograms per kilogram" .
+gistd:_UnitOfMeasure_femtogram_per_kilogram skos:scopeNote "1 femtograms per kilogram = 0.000000000000000001 x kilogram per kilogram" .
+gistd:_UnitOfMeasure_femtogram_per_liter gist:conversionFactor "0.000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_femtogram_per_liter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_femtogram_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_femtogram_per_liter skos:altLabel "femtograms per liter" .
+gistd:_UnitOfMeasure_femtogram_per_liter skos:closeMatch <http://qudt.org/vocab/unit/FemtoGM-PER-L> .
+gistd:_UnitOfMeasure_femtogram_per_liter skos:prefLabel "femtograms per liter" .
+gistd:_UnitOfMeasure_femtogram_per_liter skos:scopeNote "1 femtograms per liter = 0.000000000000001 x kilogram per meterCubed" .
 gistd:_UnitOfMeasure_femtojoule gist:conversionFactor "0.000000000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_femtojoule gist:isMemberOf gistd:_UnitGroup_energy_or_work .
 gistd:_UnitOfMeasure_femtojoule gist:isMemberOf gistd:_UnitGroup_mechanical_energy .
@@ -14139,13 +14139,13 @@ gistd:_UnitOfMeasure_femtomole skos:altLabel "femtomoles" .
 gistd:_UnitOfMeasure_femtomole skos:closeMatch <http://qudt.org/vocab/unit/FemtoMOL> .
 gistd:_UnitOfMeasure_femtomole skos:prefLabel "femtomole" .
 gistd:_UnitOfMeasure_femtomole skos:scopeNote "1 femtomole = 0.000000000000001 x mole" .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram gist:conversionFactor "0.000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram skos:altLabel "femtomoles per kilogram" .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/FemtoMOL-PER-KiloGM> .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram skos:prefLabel "femtomoles per kilogram" .
-gistd:_UnitOfMeasure_femtomoles_per_kilogram skos:scopeNote "1 femtomoles per kilogram = 0.000000000000001 x mole per kilogram" .
+gistd:_UnitOfMeasure_femtomole_per_kilogram gist:conversionFactor "0.000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_femtomole_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
+gistd:_UnitOfMeasure_femtomole_per_kilogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_femtomole_per_kilogram skos:altLabel "femtomoles per kilogram" .
+gistd:_UnitOfMeasure_femtomole_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/FemtoMOL-PER-KiloGM> .
+gistd:_UnitOfMeasure_femtomole_per_kilogram skos:prefLabel "femtomoles per kilogram" .
+gistd:_UnitOfMeasure_femtomole_per_kilogram skos:scopeNote "1 femtomoles per kilogram = 0.000000000000001 x mole per kilogram" .
 gistd:_UnitOfMeasure_fermi gist:conversionFactor "0.000000000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_fermi gist:isMemberOf gistd:_UnitGroup_distance .
 gistd:_UnitOfMeasure_fermi rdf:type gist:UnitOfMeasure .
@@ -14900,37 +14900,37 @@ gistd:_UnitOfMeasure_gram_per_square_meter skos:closeMatch <http://qudt.org/voca
 gistd:_UnitOfMeasure_gram_per_square_meter skos:definition "from QUDT: 0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" .
 gistd:_UnitOfMeasure_gram_per_square_meter skos:prefLabel "gram per square meter" .
 gistd:_UnitOfMeasure_gram_per_square_meter skos:scopeNote "1 gram per square meter = 0.001 x kilogram per meterSquared" .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day gist:conversionFactor "0.000000011574073"^^xsd:decimal .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day skos:altLabel "grams carbon per square meter per day" .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/GM_Carbon-PER-M2-DAY> .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day skos:definition "from QUDT: A metric unit of volume over time indicating the amount generated across one square meter over a day. Used to express productivity of an ecosystem." .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day skos:prefLabel "grams carbon per square meter per day" .
-gistd:_UnitOfMeasure_grams_carbon_per_square_meter_per_day skos:scopeNote "1 grams carbon per square meter per day = 0.000000011574073 x kilogram per meterSquared second" .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day gist:conversionFactor "0.000000011574073"^^xsd:decimal .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day skos:altLabel "grams nitrogen per square meter per day" .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/GM_Nitrogen-PER-M2-DAY> .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day skos:definition "from QUDT: A metric unit of volume over time indicating the amount of Nitrogen generated across one square meter over a day. Used to express productivity of an ecosystem." .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day skos:prefLabel "grams nitrogen per square meter per day" .
-gistd:_UnitOfMeasure_grams_nitrogen_per_square_meter_per_day skos:scopeNote "1 grams nitrogen per square meter per day = 0.000000011574073 x kilogram per meterSquared second" .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year gist:conversionFactor "0.000000316880878140289"^^xsd:decimal .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year skos:altLabel "grams per square centimeter per year" .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year skos:closeMatch <http://qudt.org/vocab/unit/GM-PER-CentiM2-YR> .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year skos:prefLabel "grams per square centimeter per year" .
-gistd:_UnitOfMeasure_grams_per_square_centimeter_per_year skos:scopeNote "1 grams per square centimeter per year = 0.000000316880878140289 x kilogram per meterSquared second" .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day gist:conversionFactor "0.000000011574073"^^xsd:decimal .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day skos:altLabel "grams per square meter per day" .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/GM-PER-M2-DAY> .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day skos:definition "from QUDT: A metric unit of volume over time indicating the amount generated across one square meter over a day." .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day skos:prefLabel "grams per square meter per day" .
-gistd:_UnitOfMeasure_grams_per_square_meter_per_day skos:scopeNote "1 grams per square meter per day = 0.000000011574073 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day gist:conversionFactor "0.000000011574073"^^xsd:decimal .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day skos:altLabel "grams carbon per square meter per day" .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/GM_Carbon-PER-M2-DAY> .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day skos:definition "from QUDT: A metric unit of volume over time indicating the amount generated across one square meter over a day. Used to express productivity of an ecosystem." .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day skos:prefLabel "grams carbon per square meter per day" .
+gistd:_UnitOfMeasure_gram_carbon_per_square_meter_per_day skos:scopeNote "1 grams carbon per square meter per day = 0.000000011574073 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day gist:conversionFactor "0.000000011574073"^^xsd:decimal .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day skos:altLabel "grams nitrogen per square meter per day" .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/GM_Nitrogen-PER-M2-DAY> .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day skos:definition "from QUDT: A metric unit of volume over time indicating the amount of Nitrogen generated across one square meter over a day. Used to express productivity of an ecosystem." .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day skos:prefLabel "grams nitrogen per square meter per day" .
+gistd:_UnitOfMeasure_gram_nitrogen_per_square_meter_per_day skos:scopeNote "1 grams nitrogen per square meter per day = 0.000000011574073 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year gist:conversionFactor "0.000000316880878140289"^^xsd:decimal .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year skos:altLabel "grams per square centimeter per year" .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year skos:closeMatch <http://qudt.org/vocab/unit/GM-PER-CentiM2-YR> .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year skos:prefLabel "grams per square centimeter per year" .
+gistd:_UnitOfMeasure_gram_per_square_centimeter_per_year skos:scopeNote "1 grams per square centimeter per year = 0.000000316880878140289 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day gist:conversionFactor "0.000000011574073"^^xsd:decimal .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day skos:altLabel "grams per square meter per day" .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/GM-PER-M2-DAY> .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day skos:definition "from QUDT: A metric unit of volume over time indicating the amount generated across one square meter over a day." .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day skos:prefLabel "grams per square meter per day" .
+gistd:_UnitOfMeasure_gram_per_square_meter_per_day skos:scopeNote "1 grams per square meter per day = 0.000000011574073 x kilogram per meterSquared second" .
 gistd:_UnitOfMeasure_gravity gist:conversionFactor "9.80665"^^xsd:decimal .
 gistd:_UnitOfMeasure_gravity gist:isMemberOf gistd:_UnitGroup_linear_acceleration .
 gistd:_UnitOfMeasure_gravity rdf:type gist:UnitOfMeasure .
@@ -14965,15 +14965,15 @@ gistd:_UnitOfMeasure_gross_tonnage skos:closeMatch <http://qudt.org/vocab/unit/G
 gistd:_UnitOfMeasure_gross_tonnage skos:definition "from QUDT: Gross tonnage (GT, G.T. or gt) is a nonlinear measure of a ship's overall internal volume. Gross tonnage is different from gross register tonnage. Gross tonnage is used to determine things such as a ship's manning regulations, safety rules, registration fees, and port dues, whereas the older gross register tonnage is a measure of the volume of only certain enclosed spaces." .
 gistd:_UnitOfMeasure_gross_tonnage skos:prefLabel "gross tonnage" .
 gistd:_UnitOfMeasure_gross_tonnage skos:scopeNote "1 gross tonnage = 0.0 x meterCubed" .
-gistd:_UnitOfMeasure_growing_degree_days_cereals gist:conversionFactor "86400.0e0"^^xsd:double .
-gistd:_UnitOfMeasure_growing_degree_days_cereals gist:conversionOffset "0.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_growing_degree_days_cereals gist:isMemberOf gistd:_UnitGroup_time_temperature .
-gistd:_UnitOfMeasure_growing_degree_days_cereals rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_growing_degree_days_cereals skos:altLabel "growing degree days (cereals)" .
-gistd:_UnitOfMeasure_growing_degree_days_cereals skos:closeMatch <http://qudt.org/vocab/unit/DEG_C_GROWING_CEREAL-DAY> .
-gistd:_UnitOfMeasure_growing_degree_days_cereals skos:definition "from QUDT: The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." .
-gistd:_UnitOfMeasure_growing_degree_days_cereals skos:prefLabel "growing degree days (cereals)" .
-gistd:_UnitOfMeasure_growing_degree_days_cereals skos:scopeNote "1 growing degree days (cereals) = 86400.0e0 x kelvin second" .
+gistd:_UnitOfMeasure_growing_degree_day_cereals gist:conversionFactor "86400.0e0"^^xsd:double .
+gistd:_UnitOfMeasure_growing_degree_day_cereals gist:conversionOffset "0.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_growing_degree_day_cereals gist:isMemberOf gistd:_UnitGroup_time_temperature .
+gistd:_UnitOfMeasure_growing_degree_day_cereals rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_growing_degree_day_cereals skos:altLabel "growing degree days (cereals)" .
+gistd:_UnitOfMeasure_growing_degree_day_cereals skos:closeMatch <http://qudt.org/vocab/unit/DEG_C_GROWING_CEREAL-DAY> .
+gistd:_UnitOfMeasure_growing_degree_day_cereals skos:definition "from QUDT: The sum of excess temperature over 5.5°C, where the temperature is the mean of the minimum and maximum atmospheric temperature in a day. This measure is appropriate for most cereal crops." .
+gistd:_UnitOfMeasure_growing_degree_day_cereals skos:prefLabel "growing degree days (cereals)" .
+gistd:_UnitOfMeasure_growing_degree_day_cereals skos:scopeNote "1 growing degree days (cereals) = 86400.0e0 x kelvin second" .
 gistd:_UnitOfMeasure_hartley gist:isMemberOf gistd:_UnitGroup_information_entropy .
 gistd:_UnitOfMeasure_hartley rdf:type gist:UnitOfMeasure .
 gistd:_UnitOfMeasure_hartley rdfs:seeAlso "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI .
@@ -15002,11 +15002,11 @@ gistd:_UnitOfMeasure_heart_beat rdf:type gist:UnitOfMeasure .
 gistd:_UnitOfMeasure_heart_beat skos:altLabel "heart beats" .
 gistd:_UnitOfMeasure_heart_beat skos:closeMatch <http://qudt.org/vocab/unit/HeartBeat> .
 gistd:_UnitOfMeasure_heart_beat skos:prefLabel "heart beat" .
-gistd:_UnitOfMeasure_heart_beats_per_minute gist:isMemberOf gistd:_UnitGroup_number_per_duration .
-gistd:_UnitOfMeasure_heart_beats_per_minute rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_heart_beats_per_minute skos:altLabel "heart beats per minute" .
-gistd:_UnitOfMeasure_heart_beats_per_minute skos:closeMatch <http://qudt.org/vocab/unit/BEAT-PER-MIN> .
-gistd:_UnitOfMeasure_heart_beats_per_minute skos:prefLabel "heart beats per minute" .
+gistd:_UnitOfMeasure_heart_beat_per_minute gist:isMemberOf gistd:_UnitGroup_number_per_duration .
+gistd:_UnitOfMeasure_heart_beat_per_minute rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_heart_beat_per_minute skos:altLabel "heart beats per minute" .
+gistd:_UnitOfMeasure_heart_beat_per_minute skos:closeMatch <http://qudt.org/vocab/unit/BEAT-PER-MIN> .
+gistd:_UnitOfMeasure_heart_beat_per_minute skos:prefLabel "heart beats per minute" .
 gistd:_UnitOfMeasure_hectare gist:conversionFactor "10000.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_hectare gist:isMemberOf gistd:_UnitGroup_area .
 gistd:_UnitOfMeasure_hectare rdf:type gist:UnitOfMeasure .
@@ -15091,13 +15091,13 @@ gistd:_UnitOfMeasure_hectopascal_per_kelvin skos:closeMatch <http://qudt.org/voc
 gistd:_UnitOfMeasure_hectopascal_per_kelvin skos:definition "00-fold of the SI derived unit pascal divided by the SI base unit kelvin" .
 gistd:_UnitOfMeasure_hectopascal_per_kelvin skos:prefLabel "hectopascal per kelvin" .
 gistd:_UnitOfMeasure_hectopascal_per_kelvin skos:scopeNote "1 hectopascal per kelvin = 100.0 x kilogram per kelvin meter secondSquared" .
-gistd:_UnitOfMeasure_hectopascals_per_hour gist:conversionFactor "0.0277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_hectopascals_per_hour gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
-gistd:_UnitOfMeasure_hectopascals_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_hectopascals_per_hour skos:altLabel "hectopascals per hour" .
-gistd:_UnitOfMeasure_hectopascals_per_hour skos:closeMatch <http://qudt.org/vocab/unit/HectoPA-PER-HR> .
-gistd:_UnitOfMeasure_hectopascals_per_hour skos:prefLabel "hectopascals per hour" .
-gistd:_UnitOfMeasure_hectopascals_per_hour skos:scopeNote "1 hectopascals per hour = 0.0277777777777778 x kilogram per meter secondCubed" .
+gistd:_UnitOfMeasure_hectopascal_per_hour gist:conversionFactor "0.0277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_hectopascal_per_hour gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
+gistd:_UnitOfMeasure_hectopascal_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_hectopascal_per_hour skos:altLabel "hectopascals per hour" .
+gistd:_UnitOfMeasure_hectopascal_per_hour skos:closeMatch <http://qudt.org/vocab/unit/HectoPA-PER-HR> .
+gistd:_UnitOfMeasure_hectopascal_per_hour skos:prefLabel "hectopascals per hour" .
+gistd:_UnitOfMeasure_hectopascal_per_hour skos:scopeNote "1 hectopascals per hour = 0.0277777777777778 x kilogram per meter secondCubed" .
 gistd:_UnitOfMeasure_henry gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_henry gist:isMemberOf gistd:_UnitGroup_inductance .
 gistd:_UnitOfMeasure_henry rdf:type gist:UnitOfMeasure .
@@ -15613,21 +15613,21 @@ gistd:_UnitOfMeasure_joule_square_meter_per_kilogram skos:altLabel "joule square
 gistd:_UnitOfMeasure_joule_square_meter_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/J-M2-PER-KiloGM> .
 gistd:_UnitOfMeasure_joule_square_meter_per_kilogram skos:prefLabel "joule square meter per kilogram" .
 gistd:_UnitOfMeasure_joule_square_meter_per_kilogram skos:scopeNote "1 joule square meter per kilogram = 1.0 x meterToTheFourth per secondSquared" .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin gist:isMemberOf gistd:_UnitGroup_specific_heat_capacity .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin skos:altLabel "joules per kilogram per kelvin" .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin skos:closeMatch <http://qudt.org/vocab/unit/J-PER-KiloGM-K> .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin skos:definition "from QUDT: Is part of the SI system." .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin skos:prefLabel "joules per kilogram per kelvin" .
-gistd:_UnitOfMeasure_joules_per_kilogram_per_kelvin skos:scopeNote "1 joules per kilogram per kelvin = 1.0 x meterSquared per kelvin secondSquared" .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day gist:conversionFactor "0.115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day gist:isMemberOf gistd:_UnitGroup_power_per_area .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day skos:altLabel "joules per square centimeter per day" .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day skos:closeMatch <http://qudt.org/vocab/unit/J-PER-CentiM2-DAY> .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day skos:prefLabel "joules per square centimeter per day" .
-gistd:_UnitOfMeasure_joules_per_square_centimeter_per_day skos:scopeNote "1 joules per square centimeter per day = 0.115740740740741 x kilogram per secondCubed" .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin gist:isMemberOf gistd:_UnitGroup_specific_heat_capacity .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin skos:altLabel "joules per kilogram per kelvin" .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin skos:closeMatch <http://qudt.org/vocab/unit/J-PER-KiloGM-K> .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin skos:definition "from QUDT: Is part of the SI system." .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin skos:prefLabel "joules per kilogram per kelvin" .
+gistd:_UnitOfMeasure_joule_per_kilogram_per_kelvin skos:scopeNote "1 joules per kilogram per kelvin = 1.0 x meterSquared per kelvin secondSquared" .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day gist:conversionFactor "0.115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day gist:isMemberOf gistd:_UnitGroup_power_per_area .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day skos:altLabel "joules per square centimeter per day" .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day skos:closeMatch <http://qudt.org/vocab/unit/J-PER-CentiM2-DAY> .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day skos:prefLabel "joules per square centimeter per day" .
+gistd:_UnitOfMeasure_joule_per_square_centimeter_per_day skos:scopeNote "1 joules per square centimeter per day = 0.115740740740741 x kilogram per secondCubed" .
 gistd:_UnitOfMeasure_katal gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_katal gist:isMemberOf gistd:_UnitGroup_molar_flow_rate .
 gistd:_UnitOfMeasure_katal rdf:type gist:UnitOfMeasure .
@@ -15668,13 +15668,13 @@ gistd:_UnitOfMeasure_kelvin_meter_per_watt skos:closeMatch <http://qudt.org/voca
 gistd:_UnitOfMeasure_kelvin_meter_per_watt skos:definition "from QUDT: product of the SI base unit kelvin and the SI base unit metre divided by the derived SI unit watt" .
 gistd:_UnitOfMeasure_kelvin_meter_per_watt skos:prefLabel "kelvin meter per watt" .
 gistd:_UnitOfMeasure_kelvin_meter_per_watt skos:scopeNote "1 kelvin meter per watt = 1.0 x kelvin secondCubed per kilogram meter" .
-gistd:_UnitOfMeasure_kelvin_meters gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kelvin_meters gist:isMemberOf gistd:_UnitGroup_distance_temperature .
-gistd:_UnitOfMeasure_kelvin_meters rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kelvin_meters skos:altLabel "kelvin meters" .
-gistd:_UnitOfMeasure_kelvin_meters skos:closeMatch <http://qudt.org/vocab/unit/K-M> .
-gistd:_UnitOfMeasure_kelvin_meters skos:prefLabel "kelvin meters" .
-gistd:_UnitOfMeasure_kelvin_meters skos:scopeNote "1 kelvin meters = 1.0 x kelvin meter" .
+gistd:_UnitOfMeasure_kelvin_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kelvin_meter gist:isMemberOf gistd:_UnitGroup_distance_temperature .
+gistd:_UnitOfMeasure_kelvin_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kelvin_meter skos:altLabel "kelvin meters" .
+gistd:_UnitOfMeasure_kelvin_meter skos:closeMatch <http://qudt.org/vocab/unit/K-M> .
+gistd:_UnitOfMeasure_kelvin_meter skos:prefLabel "kelvin meters" .
+gistd:_UnitOfMeasure_kelvin_meter skos:scopeNote "1 kelvin meters = 1.0 x kelvin meter" .
 gistd:_UnitOfMeasure_kelvin_per_hour gist:conversionFactor "3600.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_kelvin_per_hour gist:isMemberOf gistd:_UnitGroup_temperature_per_time .
 gistd:_UnitOfMeasure_kelvin_per_hour rdf:type gist:UnitOfMeasure .
@@ -15726,13 +15726,13 @@ gistd:_UnitOfMeasure_kelvin_second skos:altLabel "kelvin second" .
 gistd:_UnitOfMeasure_kelvin_second skos:closeMatch <http://qudt.org/vocab/unit/K-SEC> .
 gistd:_UnitOfMeasure_kelvin_second skos:prefLabel "kelvin second" .
 gistd:_UnitOfMeasure_kelvin_second skos:scopeNote "1 kelvin second = 1.0 x kelvin second" .
-gistd:_UnitOfMeasure_kelvins_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kelvins_per_meter gist:isMemberOf gistd:_UnitGroup_temperature_gradient .
-gistd:_UnitOfMeasure_kelvins_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kelvins_per_meter skos:altLabel "kelvin per meter" .
-gistd:_UnitOfMeasure_kelvins_per_meter skos:closeMatch <http://qudt.org/vocab/unit/K-PER-M> .
-gistd:_UnitOfMeasure_kelvins_per_meter skos:prefLabel "kelvins per meter" .
-gistd:_UnitOfMeasure_kelvins_per_meter skos:scopeNote "1 kelvins per meter = 1.0 x kelvin per meter" .
+gistd:_UnitOfMeasure_kelvin_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kelvin_per_meter gist:isMemberOf gistd:_UnitGroup_temperature_gradient .
+gistd:_UnitOfMeasure_kelvin_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kelvin_per_meter skos:altLabel "kelvin per meter" .
+gistd:_UnitOfMeasure_kelvin_per_meter skos:closeMatch <http://qudt.org/vocab/unit/K-PER-M> .
+gistd:_UnitOfMeasure_kelvin_per_meter skos:prefLabel "kelvins per meter" .
+gistd:_UnitOfMeasure_kelvin_per_meter skos:scopeNote "1 kelvins per meter = 1.0 x kelvin per meter" .
 gistd:_UnitOfMeasure_kibibyte gist:conversionFactor "5678.2617031470719747459655389854"^^xsd:decimal .
 gistd:_UnitOfMeasure_kibibyte gist:isMemberOf gistd:_UnitGroup_amount_of_data .
 gistd:_UnitOfMeasure_kibibyte rdf:type gist:UnitOfMeasure .
@@ -16313,56 +16313,56 @@ gistd:_UnitOfMeasure_kilogram_square_millimeter skos:closeMatch <http://qudt.org
 gistd:_UnitOfMeasure_kilogram_square_millimeter skos:definition "from QUDT: product of the SI base kilogram and the 0.001-fold of the power of the SI base metre with the exponent 2" .
 gistd:_UnitOfMeasure_kilogram_square_millimeter skos:prefLabel "kilogram square millimeter" .
 gistd:_UnitOfMeasure_kilogram_square_millimeter skos:scopeNote "1 kilogram square millimeter = 0.000001 x kilogram meterSquared" .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second skos:altLabel "kilograms per cubic meter per second" .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M3-SEC> .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second skos:prefLabel "kilograms per cubic meter per second" .
-gistd:_UnitOfMeasure_kilograms_per_cubic_meter_per_second skos:scopeNote "1 kilograms per cubic meter per second = 1.0 x kilogram per meterCubed second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour gist:conversionFactor "0.000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour gist:isMemberOf gistd:_UnitGroup_dynamic_viscosity .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour skos:altLabel "kilograms per meter per hour" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M-HR> .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour skos:prefLabel "kilograms per meter per hour" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_hour skos:scopeNote "1 kilograms per meter per hour = 0.000277777777777778 x kilogram per meter second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second gist:isMemberOf gistd:_UnitGroup_dynamic_viscosity .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second skos:altLabel "kilograms per meter per second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M-SEC> .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second skos:prefLabel "kilograms per meter per second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_second skos:scopeNote "1 kilograms per meter per second = 1.0 x kilogram per meter second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second gist:isMemberOf gistd:_UnitGroup_force_per_area .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second skos:altLabel "kilograms per meter per square second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M-SEC2> .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second skos:prefLabel "kilograms per meter per square second" .
-gistd:_UnitOfMeasure_kilograms_per_meter_per_square_second skos:scopeNote "1 kilograms per meter per square second = 1.0 x kilogram per meter secondSquared" .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer gist:isMemberOf gistd:_UnitGroup_mass_per_area .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer skos:altLabel "kilograms per square kilometer" .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-KiloM2> .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer skos:prefLabel "kilograms per square kilometer" .
-gistd:_UnitOfMeasure_kilograms_per_square_kilometer skos:scopeNote "1 kilograms per square kilometer = 0.000001 x kilogram per meterSquared" .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second gist:isMemberOf gistd:_UnitGroup_vapor_permeability .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second rdfs:seeAlso "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second skos:altLabel "kilograms per square meter per pascal per second" .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M2-PA-SEC> .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second skos:prefLabel "kilograms per square meter per pascal per second" .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_pascal_per_second skos:scopeNote "1 kilograms per square meter per pascal per second = 1.0 x second per meter" .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second skos:altLabel "kilograms per square meter per second" .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M2-SEC> .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second skos:prefLabel "kilograms per square meter per second" .
-gistd:_UnitOfMeasure_kilograms_per_square_meter_per_second skos:scopeNote "1 kilograms per square meter per second = 1.0 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second skos:altLabel "kilograms per cubic meter per second" .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M3-SEC> .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second skos:prefLabel "kilograms per cubic meter per second" .
+gistd:_UnitOfMeasure_kilogram_per_cubic_meter_per_second skos:scopeNote "1 kilograms per cubic meter per second = 1.0 x kilogram per meterCubed second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour gist:conversionFactor "0.000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour gist:isMemberOf gistd:_UnitGroup_dynamic_viscosity .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour skos:altLabel "kilograms per meter per hour" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M-HR> .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour skos:prefLabel "kilograms per meter per hour" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_hour skos:scopeNote "1 kilograms per meter per hour = 0.000277777777777778 x kilogram per meter second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second gist:isMemberOf gistd:_UnitGroup_dynamic_viscosity .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second skos:altLabel "kilograms per meter per second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M-SEC> .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second skos:prefLabel "kilograms per meter per second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_second skos:scopeNote "1 kilograms per meter per second = 1.0 x kilogram per meter second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second gist:isMemberOf gistd:_UnitGroup_force_per_area .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second skos:altLabel "kilograms per meter per square second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M-SEC2> .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second skos:prefLabel "kilograms per meter per square second" .
+gistd:_UnitOfMeasure_kilogram_per_meter_per_square_second skos:scopeNote "1 kilograms per meter per square second = 1.0 x kilogram per meter secondSquared" .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer gist:isMemberOf gistd:_UnitGroup_mass_per_area .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer skos:altLabel "kilograms per square kilometer" .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-KiloM2> .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer skos:prefLabel "kilograms per square kilometer" .
+gistd:_UnitOfMeasure_kilogram_per_square_kilometer skos:scopeNote "1 kilograms per square kilometer = 0.000001 x kilogram per meterSquared" .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second gist:isMemberOf gistd:_UnitGroup_vapor_permeability .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second rdfs:seeAlso "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second skos:altLabel "kilograms per square meter per pascal per second" .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M2-PA-SEC> .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second skos:prefLabel "kilograms per square meter per pascal per second" .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_pascal_per_second skos:scopeNote "1 kilograms per square meter per pascal per second = 1.0 x second per meter" .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second skos:altLabel "kilograms per square meter per second" .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/KiloGM-PER-M2-SEC> .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second skos:prefLabel "kilograms per square meter per second" .
+gistd:_UnitOfMeasure_kilogram_per_square_meter_per_second skos:scopeNote "1 kilograms per square meter per second = 1.0 x kilogram per meterSquared second" .
 gistd:_UnitOfMeasure_kilohertz gist:conversionFactor "1000.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_kilohertz gist:isMemberOf gistd:_UnitGroup_frequency .
 gistd:_UnitOfMeasure_kilohertz rdf:type gist:UnitOfMeasure .
@@ -16624,22 +16624,22 @@ gistd:_UnitOfMeasure_kilosecond skos:altLabel "kiloseconds" .
 gistd:_UnitOfMeasure_kilosecond skos:closeMatch <http://qudt.org/vocab/unit/KiloSEC> .
 gistd:_UnitOfMeasure_kilosecond skos:prefLabel "kilosecond" .
 gistd:_UnitOfMeasure_kilosecond skos:scopeNote "1 kilosecond = 1000.0 x second" .
-gistd:_UnitOfMeasure_kilosiemens gist:conversionFactor "1000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilosiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_kilosiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilosiemens skos:altLabel "kilosiemens" .
-gistd:_UnitOfMeasure_kilosiemens skos:closeMatch <http://qudt.org/vocab/unit/KiloS> .
-gistd:_UnitOfMeasure_kilosiemens skos:definition "1 000-fold of the SI derived unit siemens" .
-gistd:_UnitOfMeasure_kilosiemens skos:prefLabel "kilosiemens" .
-gistd:_UnitOfMeasure_kilosiemens skos:scopeNote "1 kilosiemens = 1000.0 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_kilosiemens_per_meter gist:conversionFactor "1000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_kilosiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_kilosiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_kilosiemens_per_meter skos:altLabel "kilosiemens per meter" .
-gistd:_UnitOfMeasure_kilosiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/KiloS-PER-M> .
-gistd:_UnitOfMeasure_kilosiemens_per_meter skos:definition "1 000-fold of the SI derived unit siemens divided by the SI base unit metre" .
-gistd:_UnitOfMeasure_kilosiemens_per_meter skos:prefLabel "kilosiemens per meter" .
-gistd:_UnitOfMeasure_kilosiemens_per_meter skos:scopeNote "1 kilosiemens per meter = 1000.0 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_kilosiemen gist:conversionFactor "1000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilosiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_kilosiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilosiemen skos:altLabel "kilosiemens" .
+gistd:_UnitOfMeasure_kilosiemen skos:closeMatch <http://qudt.org/vocab/unit/KiloS> .
+gistd:_UnitOfMeasure_kilosiemen skos:definition "1 000-fold of the SI derived unit siemens" .
+gistd:_UnitOfMeasure_kilosiemen skos:prefLabel "kilosiemens" .
+gistd:_UnitOfMeasure_kilosiemen skos:scopeNote "1 kilosiemens = 1000.0 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_kilosiemen_per_meter gist:conversionFactor "1000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_kilosiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_kilosiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_kilosiemen_per_meter skos:altLabel "kilosiemens per meter" .
+gistd:_UnitOfMeasure_kilosiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/KiloS-PER-M> .
+gistd:_UnitOfMeasure_kilosiemen_per_meter skos:definition "1 000-fold of the SI derived unit siemens divided by the SI base unit metre" .
+gistd:_UnitOfMeasure_kilosiemen_per_meter skos:prefLabel "kilosiemens per meter" .
+gistd:_UnitOfMeasure_kilosiemen_per_meter skos:scopeNote "1 kilosiemens per meter = 1000.0 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_kilotonne gist:conversionFactor "1000000.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_kilotonne gist:isMemberOf gistd:_UnitGroup_mass .
 gistd:_UnitOfMeasure_kilotonne rdf:type gist:UnitOfMeasure .
@@ -16876,13 +16876,13 @@ gistd:_UnitOfMeasure_liter_per_second skos:closeMatch <http://qudt.org/vocab/uni
 gistd:_UnitOfMeasure_liter_per_second skos:definition "from QUDT: unit litre divided by the SI base unit second" .
 gistd:_UnitOfMeasure_liter_per_second skos:prefLabel "liter per second" .
 gistd:_UnitOfMeasure_liter_per_second skos:scopeNote "1 liter per second = 0.001 x meterCubed per second" .
-gistd:_UnitOfMeasure_liters_per_micromole gist:conversionFactor "1000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_liters_per_micromole gist:isMemberOf gistd:_UnitGroup_molar_volume .
-gistd:_UnitOfMeasure_liters_per_micromole rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_liters_per_micromole skos:altLabel "liters per micromole" .
-gistd:_UnitOfMeasure_liters_per_micromole skos:closeMatch <http://qudt.org/vocab/unit/L-PER-MicroMOL> .
-gistd:_UnitOfMeasure_liters_per_micromole skos:prefLabel "liters per micromole" .
-gistd:_UnitOfMeasure_liters_per_micromole skos:scopeNote "1 liters per micromole = 1000.0 x meterCubed per mole" .
+gistd:_UnitOfMeasure_liter_per_micromole gist:conversionFactor "1000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_liter_per_micromole gist:isMemberOf gistd:_UnitGroup_molar_volume .
+gistd:_UnitOfMeasure_liter_per_micromole rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_liter_per_micromole skos:altLabel "liters per micromole" .
+gistd:_UnitOfMeasure_liter_per_micromole skos:closeMatch <http://qudt.org/vocab/unit/L-PER-MicroMOL> .
+gistd:_UnitOfMeasure_liter_per_micromole skos:prefLabel "liters per micromole" .
+gistd:_UnitOfMeasure_liter_per_micromole skos:scopeNote "1 liters per micromole = 1000.0 x meterCubed per mole" .
 gistd:_UnitOfMeasure_long_furlong gist:isMemberOf gistd:_UnitGroup_distance .
 gistd:_UnitOfMeasure_long_furlong rdf:type gist:UnitOfMeasure .
 gistd:_UnitOfMeasure_long_furlong skos:altLabel "long furlongs" .
@@ -17298,21 +17298,21 @@ gistd:_UnitOfMeasure_megapascal_per_kelvin skos:closeMatch <http://qudt.org/voca
 gistd:_UnitOfMeasure_megapascal_per_kelvin skos:definition ",000,000-fold of the SI derived unit pascal divided by the SI base unit kelvin" .
 gistd:_UnitOfMeasure_megapascal_per_kelvin skos:prefLabel "megapascal per kelvin" .
 gistd:_UnitOfMeasure_megapascal_per_kelvin skos:scopeNote "1 megapascal per kelvin = 1000000.0 x kilogram per kelvin meter secondSquared" .
-gistd:_UnitOfMeasure_megasiemens gist:conversionFactor "1000000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_megasiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_megasiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_megasiemens skos:altLabel "megasiemens" .
-gistd:_UnitOfMeasure_megasiemens skos:closeMatch <http://qudt.org/vocab/unit/MegaS> .
-gistd:_UnitOfMeasure_megasiemens skos:prefLabel "megasiemens" .
-gistd:_UnitOfMeasure_megasiemens skos:scopeNote "1 megasiemens = 1000000.0 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_megasiemens_per_meter gist:conversionFactor "1000000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_megasiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_megasiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_megasiemens_per_meter skos:altLabel "megasiemens per meter" .
-gistd:_UnitOfMeasure_megasiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MegaS-PER-M> .
-gistd:_UnitOfMeasure_megasiemens_per_meter skos:definition ",000,000-fold of the SI derived unit siemens divided by the SI base unit metre" .
-gistd:_UnitOfMeasure_megasiemens_per_meter skos:prefLabel "megasiemens per meter" .
-gistd:_UnitOfMeasure_megasiemens_per_meter skos:scopeNote "1 megasiemens per meter = 1000000.0 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_megasiemen gist:conversionFactor "1000000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_megasiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_megasiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_megasiemen skos:altLabel "megasiemens" .
+gistd:_UnitOfMeasure_megasiemen skos:closeMatch <http://qudt.org/vocab/unit/MegaS> .
+gistd:_UnitOfMeasure_megasiemen skos:prefLabel "megasiemens" .
+gistd:_UnitOfMeasure_megasiemen skos:scopeNote "1 megasiemens = 1000000.0 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_megasiemen_per_meter gist:conversionFactor "1000000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_megasiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_megasiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_megasiemen_per_meter skos:altLabel "megasiemens per meter" .
+gistd:_UnitOfMeasure_megasiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MegaS-PER-M> .
+gistd:_UnitOfMeasure_megasiemen_per_meter skos:definition ",000,000-fold of the SI derived unit siemens divided by the SI base unit metre" .
+gistd:_UnitOfMeasure_megasiemen_per_meter skos:prefLabel "megasiemens per meter" .
+gistd:_UnitOfMeasure_megasiemen_per_meter skos:scopeNote "1 megasiemens per meter = 1000000.0 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_megaton_of_oil_equivalent gist:conversionFactor "41868000000000000.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_megaton_of_oil_equivalent gist:isMemberOf gistd:_UnitGroup_energy_or_work .
 gistd:_UnitOfMeasure_megaton_of_oil_equivalent rdf:type gist:UnitOfMeasure .
@@ -17558,14 +17558,14 @@ gistd:_UnitOfMeasure_microampere skos:altLabel "microamperes" .
 gistd:_UnitOfMeasure_microampere skos:closeMatch <http://qudt.org/vocab/unit/MicroA> .
 gistd:_UnitOfMeasure_microampere skos:prefLabel "microampere" .
 gistd:_UnitOfMeasure_microampere skos:scopeNote "1 microampere = 0.000001 x ampere" .
-gistd:_UnitOfMeasure_microatmospheres gist:conversionFactor "0.101325"^^xsd:decimal .
-gistd:_UnitOfMeasure_microatmospheres gist:isMemberOf gistd:_UnitGroup_fluid_pressure .
-gistd:_UnitOfMeasure_microatmospheres gist:isMemberOf gistd:_UnitGroup_force_per_area .
-gistd:_UnitOfMeasure_microatmospheres rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_microatmospheres skos:altLabel "microatmospheres" .
-gistd:_UnitOfMeasure_microatmospheres skos:closeMatch <http://qudt.org/vocab/unit/MicroATM> .
-gistd:_UnitOfMeasure_microatmospheres skos:prefLabel "microatmospheres" .
-gistd:_UnitOfMeasure_microatmospheres skos:scopeNote "1 microatmospheres = 0.101325 x kilogram per meter secondSquared" .
+gistd:_UnitOfMeasure_microatmosphere gist:conversionFactor "0.101325"^^xsd:decimal .
+gistd:_UnitOfMeasure_microatmosphere gist:isMemberOf gistd:_UnitGroup_fluid_pressure .
+gistd:_UnitOfMeasure_microatmosphere gist:isMemberOf gistd:_UnitGroup_force_per_area .
+gistd:_UnitOfMeasure_microatmosphere rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microatmosphere skos:altLabel "microatmospheres" .
+gistd:_UnitOfMeasure_microatmosphere skos:closeMatch <http://qudt.org/vocab/unit/MicroATM> .
+gistd:_UnitOfMeasure_microatmosphere skos:prefLabel "microatmospheres" .
+gistd:_UnitOfMeasure_microatmosphere skos:scopeNote "1 microatmospheres = 0.101325 x kilogram per meter secondSquared" .
 gistd:_UnitOfMeasure_microbar gist:conversionFactor "0.1"^^xsd:decimal .
 gistd:_UnitOfMeasure_microbar gist:isMemberOf gistd:_UnitGroup_fluid_pressure .
 gistd:_UnitOfMeasure_microbar gist:isMemberOf gistd:_UnitGroup_force_per_area .
@@ -17692,41 +17692,41 @@ gistd:_UnitOfMeasure_microgram_per_square_centimeter skos:closeMatch <http://qud
 gistd:_UnitOfMeasure_microgram_per_square_centimeter skos:definition "from QUDT: A unit of mass per area, equivalent to 0.01 grammes per square metre" .
 gistd:_UnitOfMeasure_microgram_per_square_centimeter skos:prefLabel "microgram per square centimeter" .
 gistd:_UnitOfMeasure_microgram_per_square_centimeter skos:scopeNote "1 microgram per square centimeter = 0.01e0 x kilogram per meterSquared" .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour gist:conversionFactor "0.000000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour skos:altLabel "micrograms per cubic meter per hour" .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-M3-HR> .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour skos:prefLabel "micrograms per cubic meter per hour" .
-gistd:_UnitOfMeasure_micrograms_per_cubic_meter_per_hour skos:scopeNote "1 micrograms per cubic meter per hour = 0.000000000000277777777777778 x kilogram per meterCubed second" .
-gistd:_UnitOfMeasure_micrograms_per_gram gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micrograms_per_gram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
-gistd:_UnitOfMeasure_micrograms_per_gram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micrograms_per_gram skos:altLabel "micrograms per gram" .
-gistd:_UnitOfMeasure_micrograms_per_gram skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-GM> .
-gistd:_UnitOfMeasure_micrograms_per_gram skos:prefLabel "micrograms per gram" .
-gistd:_UnitOfMeasure_micrograms_per_gram skos:scopeNote "1 micrograms per gram = 0.000001 x kilogram per kilogram" .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour skos:altLabel "micrograms per liter per hour" .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-L-HR> .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour skos:prefLabel "micrograms per liter per hour" .
-gistd:_UnitOfMeasure_micrograms_per_liter_per_hour skos:scopeNote "1 micrograms per liter per hour = 0.000000000277777777777778 x kilogram per meterCubed second" .
-gistd:_UnitOfMeasure_micrograms_per_milliliter gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micrograms_per_milliliter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_micrograms_per_milliliter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micrograms_per_milliliter skos:altLabel "micrograms per milliliter" .
-gistd:_UnitOfMeasure_micrograms_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-MilliL> .
-gistd:_UnitOfMeasure_micrograms_per_milliliter skos:prefLabel "micrograms per milliliter" .
-gistd:_UnitOfMeasure_micrograms_per_milliliter skos:scopeNote "1 micrograms per milliliter = 0.001 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day gist:conversionFactor "0.0000000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day skos:altLabel "micrograms per square meter per day" .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-M2-DAY> .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day skos:prefLabel "micrograms per square meter per day" .
-gistd:_UnitOfMeasure_micrograms_per_square_meter_per_day skos:scopeNote "1 micrograms per square meter per day = 0.0000000000000115740740740741 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour gist:conversionFactor "0.000000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour skos:altLabel "micrograms per cubic meter per hour" .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-M3-HR> .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour skos:prefLabel "micrograms per cubic meter per hour" .
+gistd:_UnitOfMeasure_microgram_per_cubic_meter_per_hour skos:scopeNote "1 micrograms per cubic meter per hour = 0.000000000000277777777777778 x kilogram per meterCubed second" .
+gistd:_UnitOfMeasure_microgram_per_gram gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_microgram_per_gram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
+gistd:_UnitOfMeasure_microgram_per_gram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microgram_per_gram skos:altLabel "micrograms per gram" .
+gistd:_UnitOfMeasure_microgram_per_gram skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-GM> .
+gistd:_UnitOfMeasure_microgram_per_gram skos:prefLabel "micrograms per gram" .
+gistd:_UnitOfMeasure_microgram_per_gram skos:scopeNote "1 micrograms per gram = 0.000001 x kilogram per kilogram" .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour skos:altLabel "micrograms per liter per hour" .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-L-HR> .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour skos:prefLabel "micrograms per liter per hour" .
+gistd:_UnitOfMeasure_microgram_per_liter_per_hour skos:scopeNote "1 micrograms per liter per hour = 0.000000000277777777777778 x kilogram per meterCubed second" .
+gistd:_UnitOfMeasure_microgram_per_milliliter gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_microgram_per_milliliter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_microgram_per_milliliter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microgram_per_milliliter skos:altLabel "micrograms per milliliter" .
+gistd:_UnitOfMeasure_microgram_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-MilliL> .
+gistd:_UnitOfMeasure_microgram_per_milliliter skos:prefLabel "micrograms per milliliter" .
+gistd:_UnitOfMeasure_microgram_per_milliliter skos:scopeNote "1 micrograms per milliliter = 0.001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day gist:conversionFactor "0.0000000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day skos:altLabel "micrograms per square meter per day" .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MicroGM-PER-M2-DAY> .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day skos:prefLabel "micrograms per square meter per day" .
+gistd:_UnitOfMeasure_microgram_per_square_meter_per_day skos:scopeNote "1 micrograms per square meter per day = 0.0000000000000115740740740741 x kilogram per meterSquared second" .
 gistd:_UnitOfMeasure_microgravity gist:conversionFactor "0.00000980665"^^xsd:decimal .
 gistd:_UnitOfMeasure_microgravity gist:isMemberOf gistd:_UnitGroup_linear_acceleration .
 gistd:_UnitOfMeasure_microgravity rdf:type gist:UnitOfMeasure .
@@ -17814,98 +17814,98 @@ gistd:_UnitOfMeasure_micromole skos:closeMatch <http://qudt.org/vocab/unit/Micro
 gistd:_UnitOfMeasure_micromole skos:definition "from QUDT: 0.000001-fold of the SI base unit mol" .
 gistd:_UnitOfMeasure_micromole skos:prefLabel "micromole" .
 gistd:_UnitOfMeasure_micromole skos:scopeNote "1 micromole = 0.000001 x mole" .
-gistd:_UnitOfMeasure_micromoles_per_gram gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_gram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
-gistd:_UnitOfMeasure_micromoles_per_gram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_gram skos:altLabel "micromoles per gram" .
-gistd:_UnitOfMeasure_micromoles_per_gram skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-GM> .
-gistd:_UnitOfMeasure_micromoles_per_gram skos:definition "from QUDT: 0.000001-fold of the SI base unit mole divided by the 0.001-fold of the SI base unit kilogram" .
-gistd:_UnitOfMeasure_micromoles_per_gram skos:prefLabel "micromoles per gram" .
-gistd:_UnitOfMeasure_micromoles_per_gram skos:scopeNote "1 micromoles per gram = 0.001 x mole per kilogram" .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour skos:altLabel "micromoles per gram per hour" .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-GM-HR> .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour skos:prefLabel "micromoles per gram per hour" .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_hour skos:scopeNote "1 micromoles per gram per hour = 0.000000277777777777778 x mole per kilogram second" .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second gist:conversionFactor "0.0001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second skos:altLabel "micromoles per gram per second" .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-GM-SEC> .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second skos:prefLabel "micromoles per gram per second" .
-gistd:_UnitOfMeasure_micromoles_per_gram_per_second skos:scopeNote "1 micromoles per gram per second = 0.0001 x mole per kilogram second" .
-gistd:_UnitOfMeasure_micromoles_per_kilogram gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
-gistd:_UnitOfMeasure_micromoles_per_kilogram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_kilogram skos:altLabel "micromoles per kilogram" .
-gistd:_UnitOfMeasure_micromoles_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-KiloGM> .
-gistd:_UnitOfMeasure_micromoles_per_kilogram skos:prefLabel "micromoles per kilogram" .
-gistd:_UnitOfMeasure_micromoles_per_kilogram skos:scopeNote "1 micromoles per kilogram = 0.000001 x mole per kilogram" .
-gistd:_UnitOfMeasure_micromoles_per_liter gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
-gistd:_UnitOfMeasure_micromoles_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_liter skos:altLabel "micromoles per liter" .
-gistd:_UnitOfMeasure_micromoles_per_liter skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-L> .
-gistd:_UnitOfMeasure_micromoles_per_liter skos:prefLabel "micromoles per liter" .
-gistd:_UnitOfMeasure_micromoles_per_liter skos:scopeNote "1 micromoles per liter = 0.001 x mole per meterCubed" .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day gist:isMemberOf gistd:_UnitGroup_flux .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day skos:altLabel "micromoles per liter per day" .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MicroM-PER-L-DAY> .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day skos:prefLabel "micromoles per liter per day" .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_day skos:scopeNote "1 micromoles per liter per day = 0.0000000115740740740741 x per meterSquared second" .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour skos:altLabel "micromoles per liter per hour" .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-L-HR> .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour skos:prefLabel "micromoles per liter per hour" .
-gistd:_UnitOfMeasure_micromoles_per_liter_per_hour skos:scopeNote "1 micromoles per liter per hour = 0.000000277777777777778 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_micromoles_per_mole gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_mole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
-gistd:_UnitOfMeasure_micromoles_per_mole rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_mole skos:altLabel "micromoles per mole" .
-gistd:_UnitOfMeasure_micromoles_per_mole skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-MOL> .
-gistd:_UnitOfMeasure_micromoles_per_mole skos:prefLabel "micromoles per mole" .
-gistd:_UnitOfMeasure_micromoles_per_mole skos:scopeNote "1 micromoles per mole = 0.000001 x mole per mole" .
-gistd:_UnitOfMeasure_micromoles_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_second gist:isMemberOf gistd:_UnitGroup_molar_flow_rate .
-gistd:_UnitOfMeasure_micromoles_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_second skos:altLabel "micromoles per second" .
-gistd:_UnitOfMeasure_micromoles_per_second skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-SEC> .
-gistd:_UnitOfMeasure_micromoles_per_second skos:prefLabel "micromoles per second" .
-gistd:_UnitOfMeasure_micromoles_per_second skos:scopeNote "1 micromoles per second = 0.000001 x mole per second" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_square_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_area .
-gistd:_UnitOfMeasure_micromoles_per_square_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_square_meter skos:altLabel "micromoles per square meter" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2> .
-gistd:_UnitOfMeasure_micromoles_per_square_meter skos:prefLabel "micromoles per square meter" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter skos:scopeNote "1 micromoles per square meter = 0.000001 x mole per meterSquared" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day skos:altLabel "micromoles per square meter per day" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2-DAY> .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day skos:prefLabel "micromoles per square meter per day" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_day skos:scopeNote "1 micromoles per square meter per day = 0.0000000000115740740740741 x mole per meterSquared second" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour skos:altLabel "micromoles per square meter per hour" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2-HR> .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour skos:prefLabel "micromoles per square meter per hour" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_hour skos:scopeNote "1 micromoles per square meter per hour = 0.000000000277777777777778 x mole per meterSquared second" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second skos:altLabel "micromoles per square meter per second" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2-SEC> .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second skos:prefLabel "micromoles per square meter per second" .
-gistd:_UnitOfMeasure_micromoles_per_square_meter_per_second skos:scopeNote "1 micromoles per square meter per second = 0.000001 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_micromole_per_gram gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_gram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
+gistd:_UnitOfMeasure_micromole_per_gram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_gram skos:altLabel "micromoles per gram" .
+gistd:_UnitOfMeasure_micromole_per_gram skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-GM> .
+gistd:_UnitOfMeasure_micromole_per_gram skos:definition "from QUDT: 0.000001-fold of the SI base unit mole divided by the 0.001-fold of the SI base unit kilogram" .
+gistd:_UnitOfMeasure_micromole_per_gram skos:prefLabel "micromoles per gram" .
+gistd:_UnitOfMeasure_micromole_per_gram skos:scopeNote "1 micromoles per gram = 0.001 x mole per kilogram" .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour skos:altLabel "micromoles per gram per hour" .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-GM-HR> .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour skos:prefLabel "micromoles per gram per hour" .
+gistd:_UnitOfMeasure_micromole_per_gram_per_hour skos:scopeNote "1 micromoles per gram per hour = 0.000000277777777777778 x mole per kilogram second" .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second gist:conversionFactor "0.0001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second skos:altLabel "micromoles per gram per second" .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-GM-SEC> .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second skos:prefLabel "micromoles per gram per second" .
+gistd:_UnitOfMeasure_micromole_per_gram_per_second skos:scopeNote "1 micromoles per gram per second = 0.0001 x mole per kilogram second" .
+gistd:_UnitOfMeasure_micromole_per_kilogram gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
+gistd:_UnitOfMeasure_micromole_per_kilogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_kilogram skos:altLabel "micromoles per kilogram" .
+gistd:_UnitOfMeasure_micromole_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-KiloGM> .
+gistd:_UnitOfMeasure_micromole_per_kilogram skos:prefLabel "micromoles per kilogram" .
+gistd:_UnitOfMeasure_micromole_per_kilogram skos:scopeNote "1 micromoles per kilogram = 0.000001 x mole per kilogram" .
+gistd:_UnitOfMeasure_micromole_per_liter gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
+gistd:_UnitOfMeasure_micromole_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_liter skos:altLabel "micromoles per liter" .
+gistd:_UnitOfMeasure_micromole_per_liter skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-L> .
+gistd:_UnitOfMeasure_micromole_per_liter skos:prefLabel "micromoles per liter" .
+gistd:_UnitOfMeasure_micromole_per_liter skos:scopeNote "1 micromoles per liter = 0.001 x mole per meterCubed" .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day gist:isMemberOf gistd:_UnitGroup_flux .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day skos:altLabel "micromoles per liter per day" .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MicroM-PER-L-DAY> .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day skos:prefLabel "micromoles per liter per day" .
+gistd:_UnitOfMeasure_micromole_per_liter_per_day skos:scopeNote "1 micromoles per liter per day = 0.0000000115740740740741 x per meterSquared second" .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour skos:altLabel "micromoles per liter per hour" .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-L-HR> .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour skos:prefLabel "micromoles per liter per hour" .
+gistd:_UnitOfMeasure_micromole_per_liter_per_hour skos:scopeNote "1 micromoles per liter per hour = 0.000000277777777777778 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_micromole_per_mole gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_mole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
+gistd:_UnitOfMeasure_micromole_per_mole rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_mole skos:altLabel "micromoles per mole" .
+gistd:_UnitOfMeasure_micromole_per_mole skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-MOL> .
+gistd:_UnitOfMeasure_micromole_per_mole skos:prefLabel "micromoles per mole" .
+gistd:_UnitOfMeasure_micromole_per_mole skos:scopeNote "1 micromoles per mole = 0.000001 x mole per mole" .
+gistd:_UnitOfMeasure_micromole_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_second gist:isMemberOf gistd:_UnitGroup_molar_flow_rate .
+gistd:_UnitOfMeasure_micromole_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_second skos:altLabel "micromoles per second" .
+gistd:_UnitOfMeasure_micromole_per_second skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-SEC> .
+gistd:_UnitOfMeasure_micromole_per_second skos:prefLabel "micromoles per second" .
+gistd:_UnitOfMeasure_micromole_per_second skos:scopeNote "1 micromoles per second = 0.000001 x mole per second" .
+gistd:_UnitOfMeasure_micromole_per_square_meter gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_square_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_area .
+gistd:_UnitOfMeasure_micromole_per_square_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_square_meter skos:altLabel "micromoles per square meter" .
+gistd:_UnitOfMeasure_micromole_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2> .
+gistd:_UnitOfMeasure_micromole_per_square_meter skos:prefLabel "micromoles per square meter" .
+gistd:_UnitOfMeasure_micromole_per_square_meter skos:scopeNote "1 micromoles per square meter = 0.000001 x mole per meterSquared" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day skos:altLabel "micromoles per square meter per day" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2-DAY> .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day skos:prefLabel "micromoles per square meter per day" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_day skos:scopeNote "1 micromoles per square meter per day = 0.0000000000115740740740741 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour skos:altLabel "micromoles per square meter per hour" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2-HR> .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour skos:prefLabel "micromoles per square meter per hour" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_hour skos:scopeNote "1 micromoles per square meter per hour = 0.000000000277777777777778 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second skos:altLabel "micromoles per square meter per second" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MicroMOL-PER-M2-SEC> .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second skos:prefLabel "micromoles per square meter per second" .
+gistd:_UnitOfMeasure_micromole_per_square_meter_per_second skos:scopeNote "1 micromoles per square meter per second = 0.000001 x mole per meterSquared second" .
 gistd:_UnitOfMeasure_micronewton gist:conversionFactor "0.000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_micronewton gist:isMemberOf gistd:_UnitGroup_force .
 gistd:_UnitOfMeasure_micronewton rdf:type gist:UnitOfMeasure .
@@ -17962,30 +17962,30 @@ gistd:_UnitOfMeasure_microsecond skos:closeMatch <http://qudt.org/vocab/unit/Mic
 gistd:_UnitOfMeasure_microsecond skos:definition "from QUDT: Is part of the USCS system." .
 gistd:_UnitOfMeasure_microsecond skos:prefLabel "microsecond" .
 gistd:_UnitOfMeasure_microsecond skos:scopeNote "1 microsecond = 0.000001 x second" .
-gistd:_UnitOfMeasure_microsiemens gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_microsiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_microsiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_microsiemens skos:altLabel "microsiemens" .
-gistd:_UnitOfMeasure_microsiemens skos:closeMatch <http://qudt.org/vocab/unit/MicroS> .
-gistd:_UnitOfMeasure_microsiemens skos:definition "from QUDT: 0.000001-fold of the SI derived unit siemens" .
-gistd:_UnitOfMeasure_microsiemens skos:prefLabel "microsiemens" .
-gistd:_UnitOfMeasure_microsiemens skos:scopeNote "1 microsiemens = 0.000001 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter gist:conversionFactor "0.0001"^^xsd:decimal .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter skos:altLabel "microsiemens per centimeter" .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/MicroS-PER-CentiM> .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter skos:definition "from QUDT: 0.000001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter skos:prefLabel "microsiemens per centimeter" .
-gistd:_UnitOfMeasure_microsiemens_per_centimeter skos:scopeNote "1 microsiemens per centimeter = 0.0001 x ampereSquared secondCubed per kilogram meterCubed" .
-gistd:_UnitOfMeasure_microsiemens_per_meter gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_microsiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_microsiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_microsiemens_per_meter skos:altLabel "microsiemens per meter" .
-gistd:_UnitOfMeasure_microsiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MicroS-PER-M> .
-gistd:_UnitOfMeasure_microsiemens_per_meter skos:definition "from QUDT: 0.000001-fold of the SI derived unit Siemens divided by the SI base unit metre" .
-gistd:_UnitOfMeasure_microsiemens_per_meter skos:prefLabel "microsiemens per meter" .
-gistd:_UnitOfMeasure_microsiemens_per_meter skos:scopeNote "1 microsiemens per meter = 0.000001 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_microsiemen gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_microsiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_microsiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microsiemen skos:altLabel "microsiemens" .
+gistd:_UnitOfMeasure_microsiemen skos:closeMatch <http://qudt.org/vocab/unit/MicroS> .
+gistd:_UnitOfMeasure_microsiemen skos:definition "from QUDT: 0.000001-fold of the SI derived unit siemens" .
+gistd:_UnitOfMeasure_microsiemen skos:prefLabel "microsiemens" .
+gistd:_UnitOfMeasure_microsiemen skos:scopeNote "1 microsiemens = 0.000001 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter gist:conversionFactor "0.0001"^^xsd:decimal .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter skos:altLabel "microsiemens per centimeter" .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/MicroS-PER-CentiM> .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter skos:definition "from QUDT: 0.000001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter skos:prefLabel "microsiemens per centimeter" .
+gistd:_UnitOfMeasure_microsiemen_per_centimeter skos:scopeNote "1 microsiemens per centimeter = 0.0001 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_microsiemen_per_meter gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_microsiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_microsiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_microsiemen_per_meter skos:altLabel "microsiemens per meter" .
+gistd:_UnitOfMeasure_microsiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MicroS-PER-M> .
+gistd:_UnitOfMeasure_microsiemen_per_meter skos:definition "from QUDT: 0.000001-fold of the SI derived unit Siemens divided by the SI base unit metre" .
+gistd:_UnitOfMeasure_microsiemen_per_meter skos:prefLabel "microsiemens per meter" .
+gistd:_UnitOfMeasure_microsiemen_per_meter skos:scopeNote "1 microsiemens per meter = 0.000001 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_microsievert gist:conversionFactor "0.000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_microsievert gist:isMemberOf gistd:_UnitGroup_specific_energy .
 gistd:_UnitOfMeasure_microsievert rdf:type gist:UnitOfMeasure .
@@ -18413,56 +18413,56 @@ gistd:_UnitOfMeasure_milligram_per_square_meter skos:closeMatch <http://qudt.org
 gistd:_UnitOfMeasure_milligram_per_square_meter skos:definition "from QUDT: 0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" .
 gistd:_UnitOfMeasure_milligram_per_square_meter skos:prefLabel "milligram per square meter" .
 gistd:_UnitOfMeasure_milligram_per_square_meter skos:scopeNote "1 milligram per square meter = 0.000001 x kilogram per meterSquared" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day skos:altLabel "milligrams per cubic meter per day" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M3-DAY> .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day skos:prefLabel "milligrams per cubic meter per day" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_day skos:scopeNote "1 milligrams per cubic meter per day = 0.0000000000115740740740741 x kilogram per meterCubed second" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour skos:altLabel "milligrams per cubic meter per hour" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M3-HR> .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour skos:prefLabel "milligrams per cubic meter per hour" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_hour skos:scopeNote "1 milligrams per cubic meter per hour = 0.000000000277777777777778 x kilogram per meterCubed second" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second skos:altLabel "milligrams per cubic meter per second" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M3-SEC> .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second skos:prefLabel "milligrams per cubic meter per second" .
-gistd:_UnitOfMeasure_milligrams_per_cubic_meter_per_second skos:scopeNote "1 milligrams per cubic meter per second = 0.000001 x kilogram per meterCubed second" .
-gistd:_UnitOfMeasure_milligrams_per_deciliter gist:conversionFactor "0.01"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_deciliter gist:isMemberOf gistd:_UnitGroup_blood_glucose_level_by_mass .
-gistd:_UnitOfMeasure_milligrams_per_deciliter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_milligrams_per_deciliter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_deciliter skos:altLabel "milligrams per deciliter" .
-gistd:_UnitOfMeasure_milligrams_per_deciliter skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-DeciL> .
-gistd:_UnitOfMeasure_milligrams_per_deciliter skos:prefLabel "milligrams per deciliter" .
-gistd:_UnitOfMeasure_milligrams_per_deciliter skos:scopeNote "1 milligrams per deciliter = 0.01 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day skos:altLabel "milligrams per square meter per day" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M2-DAY> .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day skos:prefLabel "milligrams per square meter per day" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_day skos:scopeNote "1 milligrams per square meter per day = 0.0000000000115740740740741 x kilogram per meterSquared second" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour skos:altLabel "milligrams per square meter per hour" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M2-HR> .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour skos:prefLabel "milligrams per square meter per hour" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_hour skos:scopeNote "1 milligrams per square meter per hour = 0.000000000277777777777778 x kilogram per meterSquared second" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second skos:altLabel "milligrams per square meter per second" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M2-SEC> .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second skos:prefLabel "milligrams per square meter per second" .
-gistd:_UnitOfMeasure_milligrams_per_square_meter_per_second skos:scopeNote "1 milligrams per square meter per second = 0.000001 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day skos:altLabel "milligrams per cubic meter per day" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M3-DAY> .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day skos:prefLabel "milligrams per cubic meter per day" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_day skos:scopeNote "1 milligrams per cubic meter per day = 0.0000000000115740740740741 x kilogram per meterCubed second" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour skos:altLabel "milligrams per cubic meter per hour" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M3-HR> .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour skos:prefLabel "milligrams per cubic meter per hour" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_hour skos:scopeNote "1 milligrams per cubic meter per hour = 0.000000000277777777777778 x kilogram per meterCubed second" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_volume_per_duration .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second skos:altLabel "milligrams per cubic meter per second" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M3-SEC> .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second skos:prefLabel "milligrams per cubic meter per second" .
+gistd:_UnitOfMeasure_milligram_per_cubic_meter_per_second skos:scopeNote "1 milligrams per cubic meter per second = 0.000001 x kilogram per meterCubed second" .
+gistd:_UnitOfMeasure_milligram_per_deciliter gist:conversionFactor "0.01"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_deciliter gist:isMemberOf gistd:_UnitGroup_blood_glucose_level_by_mass .
+gistd:_UnitOfMeasure_milligram_per_deciliter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_milligram_per_deciliter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_deciliter skos:altLabel "milligrams per deciliter" .
+gistd:_UnitOfMeasure_milligram_per_deciliter skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-DeciL> .
+gistd:_UnitOfMeasure_milligram_per_deciliter skos:prefLabel "milligrams per deciliter" .
+gistd:_UnitOfMeasure_milligram_per_deciliter skos:scopeNote "1 milligrams per deciliter = 0.01 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day skos:altLabel "milligrams per square meter per day" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M2-DAY> .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day skos:prefLabel "milligrams per square meter per day" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_day skos:scopeNote "1 milligrams per square meter per day = 0.0000000000115740740740741 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour skos:altLabel "milligrams per square meter per hour" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M2-HR> .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour skos:prefLabel "milligrams per square meter per hour" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_hour skos:scopeNote "1 milligrams per square meter per hour = 0.000000000277777777777778 x kilogram per meterSquared second" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_mass_per_area_time .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second skos:altLabel "milligrams per square meter per second" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MilliGM-PER-M2-SEC> .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second skos:prefLabel "milligrams per square meter per second" .
+gistd:_UnitOfMeasure_milligram_per_square_meter_per_second skos:scopeNote "1 milligrams per square meter per second = 0.000001 x kilogram per meterSquared second" .
 gistd:_UnitOfMeasure_milligravity gist:conversionFactor "0.00980665"^^xsd:decimal .
 gistd:_UnitOfMeasure_milligravity gist:isMemberOf gistd:_UnitGroup_linear_acceleration .
 gistd:_UnitOfMeasure_milligravity rdf:type gist:UnitOfMeasure .
@@ -18673,56 +18673,56 @@ gistd:_UnitOfMeasure_millimole_per_kilogram skos:closeMatch <http://qudt.org/voc
 gistd:_UnitOfMeasure_millimole_per_kilogram skos:definition "from QUDT: 0.001-fold of the SI base unit mole divided by the SI base unit kilogram" .
 gistd:_UnitOfMeasure_millimole_per_kilogram skos:prefLabel "millimole per kilogram" .
 gistd:_UnitOfMeasure_millimole_per_kilogram skos:scopeNote "1 millimole per kilogram = 0.001 x mole per kilogram" .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter skos:altLabel "millimoles per cubic meter" .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M3> .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter skos:prefLabel "millimoles per cubic meter" .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter skos:scopeNote "1 millimoles per cubic meter = 0.001 x mole per meterCubed" .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day skos:altLabel "millimoles per cubic meter per day" .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M3-DAY> .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day skos:prefLabel "millimoles per cubic meter per day" .
-gistd:_UnitOfMeasure_millimoles_per_cubic_meter_per_day skos:scopeNote "1 millimoles per cubic meter per day = 0.0000000115740740740741 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_millimoles_per_liter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
-gistd:_UnitOfMeasure_millimoles_per_liter gist:isMemberOf gistd:_UnitGroup_blood_glucose_level .
-gistd:_UnitOfMeasure_millimoles_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_liter skos:altLabel "millimoles per liter" .
-gistd:_UnitOfMeasure_millimoles_per_liter skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-L> .
-gistd:_UnitOfMeasure_millimoles_per_liter skos:prefLabel "millimoles per liter" .
-gistd:_UnitOfMeasure_millimoles_per_liter skos:scopeNote "1 millimoles per liter = 1.0 x mole per meterCubed" .
-gistd:_UnitOfMeasure_millimoles_per_mole gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_mole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
-gistd:_UnitOfMeasure_millimoles_per_mole rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_mole skos:altLabel "millimoles per mole" .
-gistd:_UnitOfMeasure_millimoles_per_mole skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-MOL> .
-gistd:_UnitOfMeasure_millimoles_per_mole skos:prefLabel "millimoles per mole" .
-gistd:_UnitOfMeasure_millimoles_per_mole skos:scopeNote "1 millimoles per mole = 0.001 x mole per mole" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_square_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_area .
-gistd:_UnitOfMeasure_millimoles_per_square_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_square_meter skos:altLabel "millimoles per square meter" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M2> .
-gistd:_UnitOfMeasure_millimoles_per_square_meter skos:prefLabel "millimoles per square meter" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter skos:scopeNote "1 millimoles per square meter = 0.001 x mole per meterSquared" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day skos:altLabel "millimoles per square meter per day" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M2-DAY> .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day skos:prefLabel "millimoles per square meter per day" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_day skos:scopeNote "1 millimoles per square meter per day = 0.0000000115740740740741 x mole per meterSquared second" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second skos:altLabel "millimoles per square meter per second" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M2-SEC> .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second skos:prefLabel "millimoles per square meter per second" .
-gistd:_UnitOfMeasure_millimoles_per_square_meter_per_second skos:scopeNote "1 millimoles per square meter per second = 0.001 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter skos:altLabel "millimoles per cubic meter" .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M3> .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter skos:prefLabel "millimoles per cubic meter" .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter skos:scopeNote "1 millimoles per cubic meter = 0.001 x mole per meterCubed" .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day skos:altLabel "millimoles per cubic meter per day" .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M3-DAY> .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day skos:prefLabel "millimoles per cubic meter per day" .
+gistd:_UnitOfMeasure_millimole_per_cubic_meter_per_day skos:scopeNote "1 millimoles per cubic meter per day = 0.0000000115740740740741 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_millimole_per_liter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
+gistd:_UnitOfMeasure_millimole_per_liter gist:isMemberOf gistd:_UnitGroup_blood_glucose_level .
+gistd:_UnitOfMeasure_millimole_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_liter skos:altLabel "millimoles per liter" .
+gistd:_UnitOfMeasure_millimole_per_liter skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-L> .
+gistd:_UnitOfMeasure_millimole_per_liter skos:prefLabel "millimoles per liter" .
+gistd:_UnitOfMeasure_millimole_per_liter skos:scopeNote "1 millimoles per liter = 1.0 x mole per meterCubed" .
+gistd:_UnitOfMeasure_millimole_per_mole gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_mole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
+gistd:_UnitOfMeasure_millimole_per_mole rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_mole skos:altLabel "millimoles per mole" .
+gistd:_UnitOfMeasure_millimole_per_mole skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-MOL> .
+gistd:_UnitOfMeasure_millimole_per_mole skos:prefLabel "millimoles per mole" .
+gistd:_UnitOfMeasure_millimole_per_mole skos:scopeNote "1 millimoles per mole = 0.001 x mole per mole" .
+gistd:_UnitOfMeasure_millimole_per_square_meter gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_square_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_area .
+gistd:_UnitOfMeasure_millimole_per_square_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_square_meter skos:altLabel "millimoles per square meter" .
+gistd:_UnitOfMeasure_millimole_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M2> .
+gistd:_UnitOfMeasure_millimole_per_square_meter skos:prefLabel "millimoles per square meter" .
+gistd:_UnitOfMeasure_millimole_per_square_meter skos:scopeNote "1 millimoles per square meter = 0.001 x mole per meterSquared" .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day skos:altLabel "millimoles per square meter per day" .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M2-DAY> .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day skos:prefLabel "millimoles per square meter per day" .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_day skos:scopeNote "1 millimoles per square meter per day = 0.0000000115740740740741 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second skos:altLabel "millimoles per square meter per second" .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MilliMOL-PER-M2-SEC> .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second skos:prefLabel "millimoles per square meter per second" .
+gistd:_UnitOfMeasure_millimole_per_square_meter_per_second skos:scopeNote "1 millimoles per square meter per second = 0.001 x mole per meterSquared second" .
 gistd:_UnitOfMeasure_millinewton gist:conversionFactor "0.001"^^xsd:decimal .
 gistd:_UnitOfMeasure_millinewton gist:isMemberOf gistd:_UnitGroup_force .
 gistd:_UnitOfMeasure_millinewton rdf:type gist:UnitOfMeasure .
@@ -18757,17 +18757,17 @@ gistd:_UnitOfMeasure_milliohm skos:closeMatch <http://qudt.org/vocab/unit/MilliO
 gistd:_UnitOfMeasure_milliohm skos:definition "from QUDT: 0.001-fold of the SI derived unit ohm" .
 gistd:_UnitOfMeasure_milliohm skos:prefLabel "milliohm" .
 gistd:_UnitOfMeasure_milliohm skos:scopeNote "1 milliohm = 0.001 x kilogram meterSquared per ampereSquared secondCubed" .
-gistd:_UnitOfMeasure_million_US_Dollars_per_flight gist:isMemberOf gistd:_UnitGroup_monetary_value .
-gistd:_UnitOfMeasure_million_US_Dollars_per_flight rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_million_US_Dollars_per_flight skos:altLabel "million us dollars per flight" .
-gistd:_UnitOfMeasure_million_US_Dollars_per_flight skos:closeMatch <http://qudt.org/vocab/unit/MDOLLAR-PER-FLIGHT> .
-gistd:_UnitOfMeasure_million_US_Dollars_per_flight skos:closeMatch <http://qudt.org/vocab/unit/MegaDOLLAR_US-PER-FLIGHT> .
-gistd:_UnitOfMeasure_million_US_Dollars_per_flight skos:prefLabel "million us dollars per flight" .
-gistd:_UnitOfMeasure_million_US_Dollars_per_year gist:isMemberOf gistd:_UnitGroup_monetary_value_per_duration .
-gistd:_UnitOfMeasure_million_US_Dollars_per_year rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_million_US_Dollars_per_year skos:altLabel "million us dollars per year" .
-gistd:_UnitOfMeasure_million_US_Dollars_per_year skos:closeMatch <http://qudt.org/vocab/unit/MillionUSD-PER-YR> .
-gistd:_UnitOfMeasure_million_US_Dollars_per_year skos:prefLabel "million us dollars per year" .
+gistd:_UnitOfMeasure_million_US_Dollar_per_flight gist:isMemberOf gistd:_UnitGroup_monetary_value .
+gistd:_UnitOfMeasure_million_US_Dollar_per_flight rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_million_US_Dollar_per_flight skos:altLabel "million us dollars per flight" .
+gistd:_UnitOfMeasure_million_US_Dollar_per_flight skos:closeMatch <http://qudt.org/vocab/unit/MDOLLAR-PER-FLIGHT> .
+gistd:_UnitOfMeasure_million_US_Dollar_per_flight skos:closeMatch <http://qudt.org/vocab/unit/MegaDOLLAR_US-PER-FLIGHT> .
+gistd:_UnitOfMeasure_million_US_Dollar_per_flight skos:prefLabel "million us dollars per flight" .
+gistd:_UnitOfMeasure_million_US_Dollar_per_year gist:isMemberOf gistd:_UnitGroup_monetary_value_per_duration .
+gistd:_UnitOfMeasure_million_US_Dollar_per_year rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_million_US_Dollar_per_year skos:altLabel "million us dollars per year" .
+gistd:_UnitOfMeasure_million_US_Dollar_per_year skos:closeMatch <http://qudt.org/vocab/unit/MillionUSD-PER-YR> .
+gistd:_UnitOfMeasure_million_US_Dollar_per_year skos:prefLabel "million us dollars per year" .
 gistd:_UnitOfMeasure_million_years gist:conversionFactor "31557600000000.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_million_years gist:isMemberOf gistd:_UnitGroup_duration .
 gistd:_UnitOfMeasure_million_years rdf:type gist:UnitOfMeasure .
@@ -18804,13 +18804,13 @@ gistd:_UnitOfMeasure_milliradian rdf:type gist:UnitOfMeasure .
 gistd:_UnitOfMeasure_milliradian skos:altLabel "milliradians" .
 gistd:_UnitOfMeasure_milliradian skos:closeMatch <http://qudt.org/vocab/unit/MilliRAD> .
 gistd:_UnitOfMeasure_milliradian skos:prefLabel "milliradian" .
-gistd:_UnitOfMeasure_millirads_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_millirads_per_hour gist:isMemberOf gistd:_UnitGroup_absorbed_dose_rate .
-gistd:_UnitOfMeasure_millirads_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millirads_per_hour skos:altLabel "millirads per hour" .
-gistd:_UnitOfMeasure_millirads_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MilliRAD_R-PER-HR> .
-gistd:_UnitOfMeasure_millirads_per_hour skos:prefLabel "millirads per hour" .
-gistd:_UnitOfMeasure_millirads_per_hour skos:scopeNote "1 millirads per hour = 0.000000277777777777778 x meterSquared per secondCubed" .
+gistd:_UnitOfMeasure_millirad_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_millirad_per_hour gist:isMemberOf gistd:_UnitGroup_absorbed_dose_rate .
+gistd:_UnitOfMeasure_millirad_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millirad_per_hour skos:altLabel "millirads per hour" .
+gistd:_UnitOfMeasure_millirad_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MilliRAD_R-PER-HR> .
+gistd:_UnitOfMeasure_millirad_per_hour skos:prefLabel "millirads per hour" .
+gistd:_UnitOfMeasure_millirad_per_hour skos:scopeNote "1 millirads per hour = 0.000000277777777777778 x meterSquared per secondCubed" .
 gistd:_UnitOfMeasure_milliroentgen gist:conversionFactor "0.000000258"^^xsd:decimal .
 gistd:_UnitOfMeasure_milliroentgen gist:isMemberOf gistd:_UnitGroup_electric_charge_per_mass .
 gistd:_UnitOfMeasure_milliroentgen rdf:type gist:UnitOfMeasure .
@@ -18839,29 +18839,29 @@ gistd:_UnitOfMeasure_millisecond skos:definition "from QUDT: Is part of the IMPE
 gistd:_UnitOfMeasure_millisecond skos:definition "from QUDT: Is part of the USCS system." .
 gistd:_UnitOfMeasure_millisecond skos:prefLabel "millisecond" .
 gistd:_UnitOfMeasure_millisecond skos:scopeNote "1 millisecond = 0.001 x second" .
-gistd:_UnitOfMeasure_millisiemens gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_millisiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_millisiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millisiemens skos:altLabel "millisiemens" .
-gistd:_UnitOfMeasure_millisiemens skos:closeMatch <http://qudt.org/vocab/unit/MilliS> .
-gistd:_UnitOfMeasure_millisiemens skos:definition "from QUDT: 0.001-fold of the SI derived unit siemens" .
-gistd:_UnitOfMeasure_millisiemens skos:prefLabel "millisiemens" .
-gistd:_UnitOfMeasure_millisiemens skos:scopeNote "1 millisiemens = 0.001 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter gist:conversionFactor "0.1"^^xsd:decimal .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter skos:altLabel "millisiemens per centimeter" .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/MilliS-PER-CentiM> .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter skos:definition "from QUDT: 0.001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter skos:prefLabel "millisiemens per centimeter" .
-gistd:_UnitOfMeasure_millisiemens_per_centimeter skos:scopeNote "1 millisiemens per centimeter = 0.1 x ampereSquared secondCubed per kilogram meterCubed" .
-gistd:_UnitOfMeasure_millisiemens_per_meter gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_millisiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_millisiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_millisiemens_per_meter skos:altLabel "millisiemens per meter" .
-gistd:_UnitOfMeasure_millisiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MilliS-PER-M> .
-gistd:_UnitOfMeasure_millisiemens_per_meter skos:prefLabel "millisiemens per meter" .
-gistd:_UnitOfMeasure_millisiemens_per_meter skos:scopeNote "1 millisiemens per meter = 0.001 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_millisiemen gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_millisiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_millisiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millisiemen skos:altLabel "millisiemens" .
+gistd:_UnitOfMeasure_millisiemen skos:closeMatch <http://qudt.org/vocab/unit/MilliS> .
+gistd:_UnitOfMeasure_millisiemen skos:definition "from QUDT: 0.001-fold of the SI derived unit siemens" .
+gistd:_UnitOfMeasure_millisiemen skos:prefLabel "millisiemens" .
+gistd:_UnitOfMeasure_millisiemen skos:scopeNote "1 millisiemens = 0.001 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter gist:conversionFactor "0.1"^^xsd:decimal .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter skos:altLabel "millisiemens per centimeter" .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/MilliS-PER-CentiM> .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter skos:definition "from QUDT: 0.001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter skos:prefLabel "millisiemens per centimeter" .
+gistd:_UnitOfMeasure_millisiemen_per_centimeter skos:scopeNote "1 millisiemens per centimeter = 0.1 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_millisiemen_per_meter gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_millisiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_millisiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_millisiemen_per_meter skos:altLabel "millisiemens per meter" .
+gistd:_UnitOfMeasure_millisiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MilliS-PER-M> .
+gistd:_UnitOfMeasure_millisiemen_per_meter skos:prefLabel "millisiemens per meter" .
+gistd:_UnitOfMeasure_millisiemen_per_meter skos:scopeNote "1 millisiemens per meter = 0.001 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_millisievert gist:conversionFactor "0.001"^^xsd:decimal .
 gistd:_UnitOfMeasure_millisievert gist:isMemberOf gistd:_UnitGroup_specific_energy .
 gistd:_UnitOfMeasure_millisievert rdf:type gist:UnitOfMeasure .
@@ -18925,13 +18925,13 @@ gistd:_UnitOfMeasure_milliwatt_per_square_meter skos:closeMatch <http://qudt.org
 gistd:_UnitOfMeasure_milliwatt_per_square_meter skos:definition "from QUDT: 0.001-fold of the SI derived unit weber divided by the power of the SI base unit metre with the exponent 2" .
 gistd:_UnitOfMeasure_milliwatt_per_square_meter skos:prefLabel "milliwatt per square meter" .
 gistd:_UnitOfMeasure_milliwatt_per_square_meter skos:scopeNote "1 milliwatt per square meter = 0.001 x kilogram per secondCubed" .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer gist:conversionFactor "1000000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer skos:altLabel "milliwatts per square meter per nanometer" .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer skos:closeMatch <http://qudt.org/vocab/unit/MilliW-PER-M2-NanoM> .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer skos:prefLabel "milliwatts per square meter per nanometer" .
-gistd:_UnitOfMeasure_milliwatts_per_square_meter_per_nanometer skos:scopeNote "1 milliwatts per square meter per nanometer = 1000000.0 x kilogram per meter secondCubed" .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer gist:conversionFactor "1000000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer skos:altLabel "milliwatts per square meter per nanometer" .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer skos:closeMatch <http://qudt.org/vocab/unit/MilliW-PER-M2-NanoM> .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer skos:prefLabel "milliwatts per square meter per nanometer" .
+gistd:_UnitOfMeasure_milliwatt_per_square_meter_per_nanometer skos:scopeNote "1 milliwatts per square meter per nanometer = 1000000.0 x kilogram per meter secondCubed" .
 gistd:_UnitOfMeasure_milliweber gist:conversionFactor "0.001"^^xsd:decimal .
 gistd:_UnitOfMeasure_milliweber gist:isMemberOf gistd:_UnitGroup_magnetic_flux .
 gistd:_UnitOfMeasure_milliweber rdf:type gist:UnitOfMeasure .
@@ -19045,55 +19045,55 @@ gistd:_UnitOfMeasure_mole_per_second skos:closeMatch <http://qudt.org/vocab/unit
 gistd:_UnitOfMeasure_mole_per_second skos:definition "from QUDT: SI base unit mole divided by the SI base unit second" .
 gistd:_UnitOfMeasure_mole_per_second skos:prefLabel "mole per second" .
 gistd:_UnitOfMeasure_mole_per_second skos:scopeNote "1 mole per second = 1.0 x mole per second" .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second skos:altLabel "moles per cubic meter per second" .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M3-SEC> .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second skos:prefLabel "moles per cubic meter per second" .
-gistd:_UnitOfMeasure_moles_per_cubic_meter_per_second skos:scopeNote "1 moles per cubic meter per second = 1.0 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour gist:conversionFactor "0.277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour skos:altLabel "moles per gram per hour" .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-GM-HR> .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour skos:prefLabel "moles per gram per hour" .
-gistd:_UnitOfMeasure_moles_per_gram_per_hour skos:scopeNote "1 moles per gram per hour = 0.277777777777778 x mole per kilogram second" .
-gistd:_UnitOfMeasure_moles_per_mole gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_mole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
-gistd:_UnitOfMeasure_moles_per_mole rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_mole skos:altLabel "moles per mole" .
-gistd:_UnitOfMeasure_moles_per_mole skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-MOL> .
-gistd:_UnitOfMeasure_moles_per_mole skos:prefLabel "moles per mole" .
-gistd:_UnitOfMeasure_moles_per_mole skos:scopeNote "1 moles per mole = 1.0 x one" .
-gistd:_UnitOfMeasure_moles_per_square_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_square_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_area .
-gistd:_UnitOfMeasure_moles_per_square_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_square_meter skos:altLabel "moles per square meter" .
-gistd:_UnitOfMeasure_moles_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2> .
-gistd:_UnitOfMeasure_moles_per_square_meter skos:prefLabel "moles per square meter" .
-gistd:_UnitOfMeasure_moles_per_square_meter skos:scopeNote "1 moles per square meter = 1.0 x mole per meterSquared" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day gist:conversionFactor "0.0000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day skos:altLabel "moles per square meter per day" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2-DAY> .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day skos:prefLabel "moles per square meter per day" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_day skos:scopeNote "1 moles per square meter per day = 0.0000115740740740741 x mole per meterSquared second" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second skos:altLabel "moles per square meter per second" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2-SEC> .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second skos:prefLabel "moles per square meter per second" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second skos:scopeNote "1 moles per square meter per second = 1.0 x mole per meterSquared second" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter skos:altLabel "moles per square meter per second per meter" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2-SEC-M> .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter skos:prefLabel "moles per square meter per second per meter" .
-gistd:_UnitOfMeasure_moles_per_square_meter_per_second_per_meter skos:scopeNote "1 moles per square meter per second per meter = 1.0 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second skos:altLabel "moles per cubic meter per second" .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M3-SEC> .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second skos:prefLabel "moles per cubic meter per second" .
+gistd:_UnitOfMeasure_mole_per_cubic_meter_per_second skos:scopeNote "1 moles per cubic meter per second = 1.0 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour gist:conversionFactor "0.277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour skos:altLabel "moles per gram per hour" .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-GM-HR> .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour skos:prefLabel "moles per gram per hour" .
+gistd:_UnitOfMeasure_mole_per_gram_per_hour skos:scopeNote "1 moles per gram per hour = 0.277777777777778 x mole per kilogram second" .
+gistd:_UnitOfMeasure_mole_per_mole gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_mole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
+gistd:_UnitOfMeasure_mole_per_mole rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_mole skos:altLabel "moles per mole" .
+gistd:_UnitOfMeasure_mole_per_mole skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-MOL> .
+gistd:_UnitOfMeasure_mole_per_mole skos:prefLabel "moles per mole" .
+gistd:_UnitOfMeasure_mole_per_mole skos:scopeNote "1 moles per mole = 1.0 x one" .
+gistd:_UnitOfMeasure_mole_per_square_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_square_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_area .
+gistd:_UnitOfMeasure_mole_per_square_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_square_meter skos:altLabel "moles per square meter" .
+gistd:_UnitOfMeasure_mole_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2> .
+gistd:_UnitOfMeasure_mole_per_square_meter skos:prefLabel "moles per square meter" .
+gistd:_UnitOfMeasure_mole_per_square_meter skos:scopeNote "1 moles per square meter = 1.0 x mole per meterSquared" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day gist:conversionFactor "0.0000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day skos:altLabel "moles per square meter per day" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2-DAY> .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day skos:prefLabel "moles per square meter per day" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_day skos:scopeNote "1 moles per square meter per day = 0.0000115740740740741 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second skos:altLabel "moles per square meter per second" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2-SEC> .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second skos:prefLabel "moles per square meter per second" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second skos:scopeNote "1 moles per square meter per second = 1.0 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter skos:altLabel "moles per square meter per second per meter" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter skos:closeMatch <http://qudt.org/vocab/unit/MOL-PER-M2-SEC-M> .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter skos:prefLabel "moles per square meter per second per meter" .
+gistd:_UnitOfMeasure_mole_per_square_meter_per_second_per_meter skos:scopeNote "1 moles per square meter per second per meter = 1.0 x mole per meterCubed second" .
 gistd:_UnitOfMeasure_month gist:conversionFactor "2551442.976"^^xsd:decimal .
 gistd:_UnitOfMeasure_month gist:isMemberOf gistd:_UnitGroup_cycle_time .
 gistd:_UnitOfMeasure_month gist:isMemberOf gistd:_UnitGroup_duration .
@@ -19164,49 +19164,49 @@ gistd:_UnitOfMeasure_nanogram_per_kilogram skos:closeMatch <http://qudt.org/voca
 gistd:_UnitOfMeasure_nanogram_per_kilogram skos:definition "from QUDT: mass ratio consisting of the 0.000000000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" .
 gistd:_UnitOfMeasure_nanogram_per_kilogram skos:prefLabel "nanogram per kilogram" .
 gistd:_UnitOfMeasure_nanogram_per_kilogram skos:scopeNote "1 nanogram per kilogram = 0.000000000001 x kilogram per kilogram" .
-gistd:_UnitOfMeasure_nanograms gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanograms gist:isMemberOf gistd:_UnitGroup_mass .
-gistd:_UnitOfMeasure_nanograms rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanograms skos:altLabel "nanograms" .
-gistd:_UnitOfMeasure_nanograms skos:closeMatch <http://qudt.org/vocab/unit/NanoGM> .
-gistd:_UnitOfMeasure_nanograms skos:prefLabel "nanograms" .
-gistd:_UnitOfMeasure_nanograms skos:scopeNote "1 nanograms = 0.000000000001 x kilogram" .
-gistd:_UnitOfMeasure_nanograms_per_day gist:conversionFactor "0.0000000000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanograms_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_time .
-gistd:_UnitOfMeasure_nanograms_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanograms_per_day skos:altLabel "nanograms per day" .
-gistd:_UnitOfMeasure_nanograms_per_day skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-DAY> .
-gistd:_UnitOfMeasure_nanograms_per_day skos:prefLabel "nanograms per day" .
-gistd:_UnitOfMeasure_nanograms_per_day skos:scopeNote "1 nanograms per day = 0.0000000000000000115740740740741 x kilogram per second" .
-gistd:_UnitOfMeasure_nanograms_per_liter gist:conversionFactor "0.000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanograms_per_liter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_nanograms_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanograms_per_liter skos:altLabel "nanograms per liter" .
-gistd:_UnitOfMeasure_nanograms_per_liter skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-L> .
-gistd:_UnitOfMeasure_nanograms_per_liter skos:prefLabel "nanograms per liter" .
-gistd:_UnitOfMeasure_nanograms_per_liter skos:scopeNote "1 nanograms per liter = 0.000000001 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_nanograms_per_microliter gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanograms_per_microliter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_nanograms_per_microliter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanograms_per_microliter skos:altLabel "nanograms per microliter" .
-gistd:_UnitOfMeasure_nanograms_per_microliter skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-MicroL> .
-gistd:_UnitOfMeasure_nanograms_per_microliter skos:prefLabel "nanograms per microliter" .
-gistd:_UnitOfMeasure_nanograms_per_microliter skos:scopeNote "1 nanograms per microliter = 0.001 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_nanograms_per_milliliter gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanograms_per_milliliter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_nanograms_per_milliliter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanograms_per_milliliter skos:altLabel "nanograms per milliliter" .
-gistd:_UnitOfMeasure_nanograms_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-MilliL> .
-gistd:_UnitOfMeasure_nanograms_per_milliliter skos:prefLabel "nanograms per milliliter" .
-gistd:_UnitOfMeasure_nanograms_per_milliliter skos:scopeNote "1 nanograms per milliliter = 0.000001 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second gist:isMemberOf gistd:_UnitGroup_vapor_permeability .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second rdfs:seeAlso "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second skos:altLabel "nanograms per square meter per pascal per second" .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-M2-PA-SEC> .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second skos:prefLabel "nanograms per square meter per pascal per second" .
-gistd:_UnitOfMeasure_nanograms_per_square_meter_per_pascal_per_second skos:scopeNote "1 nanograms per square meter per pascal per second = 0.000000000001 x second per meter" .
+gistd:_UnitOfMeasure_nanogram gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanogram gist:isMemberOf gistd:_UnitGroup_mass .
+gistd:_UnitOfMeasure_nanogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanogram skos:altLabel "nanograms" .
+gistd:_UnitOfMeasure_nanogram skos:closeMatch <http://qudt.org/vocab/unit/NanoGM> .
+gistd:_UnitOfMeasure_nanogram skos:prefLabel "nanograms" .
+gistd:_UnitOfMeasure_nanogram skos:scopeNote "1 nanograms = 0.000000000001 x kilogram" .
+gistd:_UnitOfMeasure_nanogram_per_day gist:conversionFactor "0.0000000000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanogram_per_day gist:isMemberOf gistd:_UnitGroup_mass_per_time .
+gistd:_UnitOfMeasure_nanogram_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanogram_per_day skos:altLabel "nanograms per day" .
+gistd:_UnitOfMeasure_nanogram_per_day skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-DAY> .
+gistd:_UnitOfMeasure_nanogram_per_day skos:prefLabel "nanograms per day" .
+gistd:_UnitOfMeasure_nanogram_per_day skos:scopeNote "1 nanograms per day = 0.0000000000000000115740740740741 x kilogram per second" .
+gistd:_UnitOfMeasure_nanogram_per_liter gist:conversionFactor "0.000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanogram_per_liter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_nanogram_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanogram_per_liter skos:altLabel "nanograms per liter" .
+gistd:_UnitOfMeasure_nanogram_per_liter skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-L> .
+gistd:_UnitOfMeasure_nanogram_per_liter skos:prefLabel "nanograms per liter" .
+gistd:_UnitOfMeasure_nanogram_per_liter skos:scopeNote "1 nanograms per liter = 0.000000001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_nanogram_per_microliter gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanogram_per_microliter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_nanogram_per_microliter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanogram_per_microliter skos:altLabel "nanograms per microliter" .
+gistd:_UnitOfMeasure_nanogram_per_microliter skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-MicroL> .
+gistd:_UnitOfMeasure_nanogram_per_microliter skos:prefLabel "nanograms per microliter" .
+gistd:_UnitOfMeasure_nanogram_per_microliter skos:scopeNote "1 nanograms per microliter = 0.001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_nanogram_per_milliliter gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanogram_per_milliliter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_nanogram_per_milliliter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanogram_per_milliliter skos:altLabel "nanograms per milliliter" .
+gistd:_UnitOfMeasure_nanogram_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-MilliL> .
+gistd:_UnitOfMeasure_nanogram_per_milliliter skos:prefLabel "nanograms per milliliter" .
+gistd:_UnitOfMeasure_nanogram_per_milliliter skos:scopeNote "1 nanograms per milliliter = 0.000001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second gist:isMemberOf gistd:_UnitGroup_vapor_permeability .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second rdfs:seeAlso "https://en.wikipedia.org/wiki/Perm_(unit)"^^xsd:anyURI .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second skos:altLabel "nanograms per square meter per pascal per second" .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second skos:closeMatch <http://qudt.org/vocab/unit/NanoGM-PER-M2-PA-SEC> .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second skos:prefLabel "nanograms per square meter per pascal per second" .
+gistd:_UnitOfMeasure_nanogram_per_square_meter_per_pascal_per_second skos:scopeNote "1 nanograms per square meter per pascal per second = 0.000000000001 x second per meter" .
 gistd:_UnitOfMeasure_nanohenry gist:conversionFactor "0.000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_nanohenry gist:isMemberOf gistd:_UnitGroup_inductance .
 gistd:_UnitOfMeasure_nanohenry rdf:type gist:UnitOfMeasure .
@@ -19263,70 +19263,70 @@ gistd:_UnitOfMeasure_nanomole skos:altLabel "nanomoles" .
 gistd:_UnitOfMeasure_nanomole skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL> .
 gistd:_UnitOfMeasure_nanomole skos:prefLabel "nanomole" .
 gistd:_UnitOfMeasure_nanomole skos:scopeNote "1 nanomole = 0.000000001 x mole" .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour skos:altLabel "nanomoles per cubic centimeter per hour" .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-CentiM3-HR> .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour skos:prefLabel "nanomoles per cubic centimeter per hour" .
-gistd:_UnitOfMeasure_nanomoles_per_cubic_centimeter_per_hour skos:scopeNote "1 nanomoles per cubic centimeter per hour = 0.000000277777777777778 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second skos:altLabel "nanomoles per gram per second" .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-GM-SEC> .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second skos:prefLabel "nanomoles per gram per second" .
-gistd:_UnitOfMeasure_nanomoles_per_gram_per_second skos:scopeNote "1 nanomoles per gram per second = 0.000001 x mole per kilogram second" .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram gist:conversionFactor "0.000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram skos:altLabel "nanomoles per kilogram" .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-KiloGM> .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram skos:prefLabel "nanomoles per kilogram" .
-gistd:_UnitOfMeasure_nanomoles_per_kilogram skos:scopeNote "1 nanomoles per kilogram = 0.000000001 x mole per kilogram" .
-gistd:_UnitOfMeasure_nanomoles_per_liter gist:conversionFactor "0.000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
-gistd:_UnitOfMeasure_nanomoles_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_liter skos:altLabel "nanomoles per liter" .
-gistd:_UnitOfMeasure_nanomoles_per_liter skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-L> .
-gistd:_UnitOfMeasure_nanomoles_per_liter skos:prefLabel "nanomoles per liter" .
-gistd:_UnitOfMeasure_nanomoles_per_liter skos:scopeNote "1 nanomoles per liter = 0.000001 x mole per meterCubed" .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day skos:altLabel "nanomoles per liter per day" .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-L-DAY> .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day skos:prefLabel "nanomoles per liter per day" .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_day skos:scopeNote "1 nanomoles per liter per day = 0.0000000000115740740740741 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour skos:altLabel "nanomoles per liter per hour" .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-L-HR> .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour skos:prefLabel "nanomoles per liter per hour" .
-gistd:_UnitOfMeasure_nanomoles_per_liter_per_hour skos:scopeNote "1 nanomoles per liter per hour = 0.000000000277777777777778 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour gist:conversionFactor "0.000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour skos:altLabel "nanomoles per microgram per hour" .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-MicroGM-HR> .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour skos:prefLabel "nanomoles per microgram per hour" .
-gistd:_UnitOfMeasure_nanomoles_per_microgram_per_hour skos:scopeNote "1 nanomoles per microgram per hour = 0.000277777777777778 x mole per kilogram second" .
-gistd:_UnitOfMeasure_nanomoles_per_micromole gist:conversionFactor "0.001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_micromole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
-gistd:_UnitOfMeasure_nanomoles_per_micromole rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_micromole skos:altLabel "nanomoles per micromole" .
-gistd:_UnitOfMeasure_nanomoles_per_micromole skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-MicroMOL> .
-gistd:_UnitOfMeasure_nanomoles_per_micromole skos:prefLabel "nanomoles per micromole" .
-gistd:_UnitOfMeasure_nanomoles_per_micromole skos:scopeNote "1 nanomoles per micromole = 0.001 x mole per mole" .
-gistd:_UnitOfMeasure_nanomoles_per_micromole_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day gist:conversionFactor "0.0000000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day skos:altLabel "nanomoles per square meter per day" .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-M2-DAY> .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day skos:prefLabel "nanomoles per square meter per day" .
-gistd:_UnitOfMeasure_nanomoles_per_square_meter_per_day skos:scopeNote "1 nanomoles per square meter per day = 0.0000000000000115740740740741 x mole per meterSquared second" .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour gist:conversionFactor "0.000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour skos:altLabel "nanomoles per cubic centimeter per hour" .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-CentiM3-HR> .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour skos:prefLabel "nanomoles per cubic centimeter per hour" .
+gistd:_UnitOfMeasure_nanomole_per_cubic_centimeter_per_hour skos:scopeNote "1 nanomoles per cubic centimeter per hour = 0.000000277777777777778 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second skos:altLabel "nanomoles per gram per second" .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-GM-SEC> .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second skos:prefLabel "nanomoles per gram per second" .
+gistd:_UnitOfMeasure_nanomole_per_gram_per_second skos:scopeNote "1 nanomoles per gram per second = 0.000001 x mole per kilogram second" .
+gistd:_UnitOfMeasure_nanomole_per_kilogram gist:conversionFactor "0.000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
+gistd:_UnitOfMeasure_nanomole_per_kilogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_kilogram skos:altLabel "nanomoles per kilogram" .
+gistd:_UnitOfMeasure_nanomole_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-KiloGM> .
+gistd:_UnitOfMeasure_nanomole_per_kilogram skos:prefLabel "nanomoles per kilogram" .
+gistd:_UnitOfMeasure_nanomole_per_kilogram skos:scopeNote "1 nanomoles per kilogram = 0.000000001 x mole per kilogram" .
+gistd:_UnitOfMeasure_nanomole_per_liter gist:conversionFactor "0.000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
+gistd:_UnitOfMeasure_nanomole_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_liter skos:altLabel "nanomoles per liter" .
+gistd:_UnitOfMeasure_nanomole_per_liter skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-L> .
+gistd:_UnitOfMeasure_nanomole_per_liter skos:prefLabel "nanomoles per liter" .
+gistd:_UnitOfMeasure_nanomole_per_liter skos:scopeNote "1 nanomoles per liter = 0.000001 x mole per meterCubed" .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day gist:conversionFactor "0.0000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day skos:altLabel "nanomoles per liter per day" .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-L-DAY> .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day skos:prefLabel "nanomoles per liter per day" .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_day skos:scopeNote "1 nanomoles per liter per day = 0.0000000000115740740740741 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour gist:conversionFactor "0.000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour skos:altLabel "nanomoles per liter per hour" .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-L-HR> .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour skos:prefLabel "nanomoles per liter per hour" .
+gistd:_UnitOfMeasure_nanomole_per_liter_per_hour skos:scopeNote "1 nanomoles per liter per hour = 0.000000000277777777777778 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour gist:conversionFactor "0.000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_mass_per_duration .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour skos:altLabel "nanomoles per microgram per hour" .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-MicroGM-HR> .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour skos:prefLabel "nanomoles per microgram per hour" .
+gistd:_UnitOfMeasure_nanomole_per_microgram_per_hour skos:scopeNote "1 nanomoles per microgram per hour = 0.000277777777777778 x mole per kilogram second" .
+gistd:_UnitOfMeasure_nanomole_per_micromole gist:conversionFactor "0.001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_micromole gist:isMemberOf gistd:_UnitGroup_ratio_of_amount_of_substance .
+gistd:_UnitOfMeasure_nanomole_per_micromole rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_micromole skos:altLabel "nanomoles per micromole" .
+gistd:_UnitOfMeasure_nanomole_per_micromole skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-MicroMOL> .
+gistd:_UnitOfMeasure_nanomole_per_micromole skos:prefLabel "nanomoles per micromole" .
+gistd:_UnitOfMeasure_nanomole_per_micromole skos:scopeNote "1 nanomoles per micromole = 0.001 x mole per mole" .
+gistd:_UnitOfMeasure_nanomole_per_micromole_per_day gist:conversionFactor "0.0000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day gist:conversionFactor "0.0000000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day gist:isMemberOf gistd:_UnitGroup_photosynthetic_photon_flux_density .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day skos:altLabel "nanomoles per square meter per day" .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day skos:closeMatch <http://qudt.org/vocab/unit/NanoMOL-PER-M2-DAY> .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day skos:prefLabel "nanomoles per square meter per day" .
+gistd:_UnitOfMeasure_nanomole_per_square_meter_per_day skos:scopeNote "1 nanomoles per square meter per day = 0.0000000000000115740740740741 x mole per meterSquared second" .
 gistd:_UnitOfMeasure_nanosecond gist:conversionFactor "0.000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_nanosecond gist:isMemberOf gistd:_UnitGroup_duration .
 gistd:_UnitOfMeasure_nanosecond rdf:type gist:UnitOfMeasure .
@@ -19335,29 +19335,29 @@ gistd:_UnitOfMeasure_nanosecond skos:altLabel "nanoseconds" .
 gistd:_UnitOfMeasure_nanosecond skos:closeMatch <http://qudt.org/vocab/unit/NanoSEC> .
 gistd:_UnitOfMeasure_nanosecond skos:prefLabel "nanosecond" .
 gistd:_UnitOfMeasure_nanosecond skos:scopeNote "1 nanosecond = 0.000000001 x second" .
-gistd:_UnitOfMeasure_nanosiemens gist:conversionFactor "0.000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanosiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_nanosiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanosiemens skos:altLabel "nanosiemens" .
-gistd:_UnitOfMeasure_nanosiemens skos:closeMatch <http://qudt.org/vocab/unit/NanoS> .
-gistd:_UnitOfMeasure_nanosiemens skos:prefLabel "nanosiemens" .
-gistd:_UnitOfMeasure_nanosiemens skos:scopeNote "1 nanosiemens = 0.000000001 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter gist:conversionFactor "0.0000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter skos:altLabel "nanosiemens per centimeter" .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/NanoS-PER-CentiM> .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter skos:definition "from QUDT: 0.000000001-fold of the SI derived unit Siemens by the 0.01 fol of the SI base unit metre" .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter skos:prefLabel "nanosiemens per centimeter" .
-gistd:_UnitOfMeasure_nanosiemens_per_centimeter skos:scopeNote "1 nanosiemens per centimeter = 0.0000001 x ampereSquared secondCubed per kilogram meterCubed" .
-gistd:_UnitOfMeasure_nanosiemens_per_meter gist:conversionFactor "0.000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_nanosiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_nanosiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_nanosiemens_per_meter skos:altLabel "nanosiemens per meter" .
-gistd:_UnitOfMeasure_nanosiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/NanoS-PER-M> .
-gistd:_UnitOfMeasure_nanosiemens_per_meter skos:definition "from QUDT: 0.000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" .
-gistd:_UnitOfMeasure_nanosiemens_per_meter skos:prefLabel "nanosiemens per meter" .
-gistd:_UnitOfMeasure_nanosiemens_per_meter skos:scopeNote "1 nanosiemens per meter = 0.000000001 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_nanosiemen gist:conversionFactor "0.000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanosiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_nanosiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanosiemen skos:altLabel "nanosiemens" .
+gistd:_UnitOfMeasure_nanosiemen skos:closeMatch <http://qudt.org/vocab/unit/NanoS> .
+gistd:_UnitOfMeasure_nanosiemen skos:prefLabel "nanosiemens" .
+gistd:_UnitOfMeasure_nanosiemen skos:scopeNote "1 nanosiemens = 0.000000001 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter gist:conversionFactor "0.0000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter skos:altLabel "nanosiemens per centimeter" .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/NanoS-PER-CentiM> .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter skos:definition "from QUDT: 0.000000001-fold of the SI derived unit Siemens by the 0.01 fol of the SI base unit metre" .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter skos:prefLabel "nanosiemens per centimeter" .
+gistd:_UnitOfMeasure_nanosiemen_per_centimeter skos:scopeNote "1 nanosiemens per centimeter = 0.0000001 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_nanosiemen_per_meter gist:conversionFactor "0.000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_nanosiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_nanosiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_nanosiemen_per_meter skos:altLabel "nanosiemens per meter" .
+gistd:_UnitOfMeasure_nanosiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/NanoS-PER-M> .
+gistd:_UnitOfMeasure_nanosiemen_per_meter skos:definition "from QUDT: 0.000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" .
+gistd:_UnitOfMeasure_nanosiemen_per_meter skos:prefLabel "nanosiemens per meter" .
+gistd:_UnitOfMeasure_nanosiemen_per_meter skos:scopeNote "1 nanosiemens per meter = 0.000000001 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_nanotesla gist:conversionFactor "0.000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_nanotesla gist:isMemberOf gistd:_UnitGroup_magnetic_flux_density .
 gistd:_UnitOfMeasure_nanotesla rdf:type gist:UnitOfMeasure .
@@ -19475,13 +19475,13 @@ gistd:_UnitOfMeasure_newton_meter_per_meter skos:closeMatch <http://qudt.org/voc
 gistd:_UnitOfMeasure_newton_meter_per_meter skos:definition "from QUDT: This is the SI unit for the rolling resistance, which is equivalent to drag force in newton" .
 gistd:_UnitOfMeasure_newton_meter_per_meter skos:prefLabel "newton meter per meter" .
 gistd:_UnitOfMeasure_newton_meter_per_meter skos:scopeNote "1 newton meter per meter = 1.0 x kilogram meter per secondSquared" .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians gist:isMemberOf gistd:_UnitGroup_force_per_angle .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians skos:altLabel "newton meters per meter per radians" .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians skos:closeMatch <http://qudt.org/vocab/unit/N-M-PER-M-RAD> .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians skos:prefLabel "newton meter per meter per radians" .
-gistd:_UnitOfMeasure_newton_meter_per_meter_per_radians skos:scopeNote "1 newton meter per meter per radians = 1.0 x kilogram meter per radian secondSquared" .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian gist:isMemberOf gistd:_UnitGroup_force_per_angle .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian skos:altLabel "newton meters per meter per radians" .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian skos:closeMatch <http://qudt.org/vocab/unit/N-M-PER-M-RAD> .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian skos:prefLabel "newton meter per meter per radians" .
+gistd:_UnitOfMeasure_newton_meter_per_meter_per_radian skos:scopeNote "1 newton meter per meter per radians = 1.0 x kilogram meter per radian secondSquared" .
 gistd:_UnitOfMeasure_newton_meter_per_radian gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_newton_meter_per_radian gist:conversionOffset "0.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_newton_meter_per_radian gist:isMemberOf gistd:_UnitGroup_torque_per_angle .
@@ -19507,24 +19507,24 @@ gistd:_UnitOfMeasure_newton_meter_second skos:altLabel "newton meter seconds" .
 gistd:_UnitOfMeasure_newton_meter_second skos:closeMatch <http://qudt.org/vocab/unit/N-M-SEC> .
 gistd:_UnitOfMeasure_newton_meter_second skos:prefLabel "newton meter second" .
 gistd:_UnitOfMeasure_newton_meter_second skos:scopeNote "1 newton meter second = 1.0 x kilogram meterSquared per second" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter gist:conversionOffset "0.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter gist:isMemberOf gistd:_UnitGroup_momentum .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter skos:altLabel "newton meter seconds per meter" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter skos:closeMatch <http://qudt.org/vocab/unit/N-M-SEC-PER-M> .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter skos:definition "from QUDT: Newton metre seconds measured per metre" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter skos:prefLabel "newton meter seconds per meter" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_meter skos:scopeNote "1 newton meter seconds per meter = 1.0 x kilogram meter per second" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian gist:conversionOffset "0.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian gist:isMemberOf gistd:_UnitGroup_angular_momentum_per_angle .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian skos:altLabel "newton meter seconds per radian" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian skos:closeMatch <http://qudt.org/vocab/unit/N-M-SEC-PER-RAD> .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian skos:definition "from QUDT: Newton metre seconds measured per radian" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian skos:prefLabel "newton meter seconds per radian" .
-gistd:_UnitOfMeasure_newton_meter_seconds_per_radian skos:scopeNote "1 newton meter seconds per radian = 1.0 x kilogram meterSquared per radian second" .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter gist:conversionOffset "0.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter gist:isMemberOf gistd:_UnitGroup_momentum .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter skos:altLabel "newton meter seconds per meter" .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter skos:closeMatch <http://qudt.org/vocab/unit/N-M-SEC-PER-M> .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter skos:definition "from QUDT: Newton metre seconds measured per metre" .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter skos:prefLabel "newton meter seconds per meter" .
+gistd:_UnitOfMeasure_newton_meter_second_per_meter skos:scopeNote "1 newton meter seconds per meter = 1.0 x kilogram meter per second" .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian gist:conversionOffset "0.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian gist:isMemberOf gistd:_UnitGroup_angular_momentum_per_angle .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian skos:altLabel "newton meter seconds per radian" .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian skos:closeMatch <http://qudt.org/vocab/unit/N-M-SEC-PER-RAD> .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian skos:definition "from QUDT: Newton metre seconds measured per radian" .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian skos:prefLabel "newton meter seconds per radian" .
+gistd:_UnitOfMeasure_newton_meter_second_per_radian skos:scopeNote "1 newton meter seconds per radian = 1.0 x kilogram meterSquared per radian second" .
 gistd:_UnitOfMeasure_newton_meter_squared_per_ampere gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_newton_meter_squared_per_ampere gist:isMemberOf gistd:_UnitGroup_magnetic_dipole_moment .
 gistd:_UnitOfMeasure_newton_meter_squared_per_ampere rdf:type gist:UnitOfMeasure .
@@ -19649,15 +19649,15 @@ gistd:_UnitOfMeasure_newton_second_per_meter skos:closeMatch <http://qudt.org/vo
 gistd:_UnitOfMeasure_newton_second_per_meter skos:definition "from QUDT: Newton second measured per metre" .
 gistd:_UnitOfMeasure_newton_second_per_meter skos:prefLabel "newton second per meter" .
 gistd:_UnitOfMeasure_newton_second_per_meter skos:scopeNote "1 newton second per meter = 1.0 x kilogram per second" .
-gistd:_UnitOfMeasure_newton_seconds_per_radian gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_seconds_per_radian gist:conversionOffset "0.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newton_seconds_per_radian gist:isMemberOf gistd:_UnitGroup_momentum_per_angle .
-gistd:_UnitOfMeasure_newton_seconds_per_radian rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_newton_seconds_per_radian skos:altLabel "newton seconds per radian" .
-gistd:_UnitOfMeasure_newton_seconds_per_radian skos:closeMatch <http://qudt.org/vocab/unit/N-SEC-PER-RAD> .
-gistd:_UnitOfMeasure_newton_seconds_per_radian skos:definition "from QUDT: Newton seconds measured per radian" .
-gistd:_UnitOfMeasure_newton_seconds_per_radian skos:prefLabel "newton seconds per radian" .
-gistd:_UnitOfMeasure_newton_seconds_per_radian skos:scopeNote "1 newton seconds per radian = 1.0 x kilogram meter per radian second" .
+gistd:_UnitOfMeasure_newton_second_per_radian gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_second_per_radian gist:conversionOffset "0.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_second_per_radian gist:isMemberOf gistd:_UnitGroup_momentum_per_angle .
+gistd:_UnitOfMeasure_newton_second_per_radian rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_newton_second_per_radian skos:altLabel "newton seconds per radian" .
+gistd:_UnitOfMeasure_newton_second_per_radian skos:closeMatch <http://qudt.org/vocab/unit/N-SEC-PER-RAD> .
+gistd:_UnitOfMeasure_newton_second_per_radian skos:definition "from QUDT: Newton seconds measured per radian" .
+gistd:_UnitOfMeasure_newton_second_per_radian skos:prefLabel "newton seconds per radian" .
+gistd:_UnitOfMeasure_newton_second_per_radian skos:scopeNote "1 newton seconds per radian = 1.0 x kilogram meter per radian second" .
 gistd:_UnitOfMeasure_newton_square_meter gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_newton_square_meter gist:isMemberOf gistd:_UnitGroup_distance_energy .
 gistd:_UnitOfMeasure_newton_square_meter rdf:type gist:UnitOfMeasure .
@@ -19673,13 +19673,13 @@ gistd:_UnitOfMeasure_newton_square_meter_per_square_kilogram skos:closeMatch <ht
 gistd:_UnitOfMeasure_newton_square_meter_per_square_kilogram skos:definition "from QUDT: unit of gravitational constant as product of the derived SI unit newton, the power of the SI base unit metre with the exponent 2 divided by the power of the SI base unit kilogram with the exponent 2" .
 gistd:_UnitOfMeasure_newton_square_meter_per_square_kilogram skos:prefLabel "newton square meter per square kilogram" .
 gistd:_UnitOfMeasure_newton_square_meter_per_square_kilogram skos:scopeNote "1 newton square meter per square kilogram = 1.0 x meterCubed per kilogram secondSquared" .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_spectral_radiant_energy_density .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter skos:altLabel "newtons per cubic meter" .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/N-PER-M3> .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter skos:prefLabel "newtons per cubic meter" .
-gistd:_UnitOfMeasure_newtons_per_cubic_meter skos:scopeNote "1 newtons per cubic meter = 1.0 x kilogram per meterSquared secondSquared" .
+gistd:_UnitOfMeasure_newton_per_cubic_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_newton_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_spectral_radiant_energy_density .
+gistd:_UnitOfMeasure_newton_per_cubic_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_newton_per_cubic_meter skos:altLabel "newtons per cubic meter" .
+gistd:_UnitOfMeasure_newton_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/N-PER-M3> .
+gistd:_UnitOfMeasure_newton_per_cubic_meter skos:prefLabel "newtons per cubic meter" .
+gistd:_UnitOfMeasure_newton_per_cubic_meter skos:scopeNote "1 newtons per cubic meter = 1.0 x kilogram per meterSquared secondSquared" .
 gistd:_UnitOfMeasure_number gist:isMemberOf gistd:_UnitGroup_number .
 gistd:_UnitOfMeasure_number gist:isMemberOf gistd:_UnitGroup_probability .
 gistd:_UnitOfMeasure_number gist:isMemberOf gistd:_UnitGroup_quantum_number .
@@ -20105,13 +20105,13 @@ gistd:_UnitOfMeasure_pascal_meter_per_second skos:altLabel "pascal meters per se
 gistd:_UnitOfMeasure_pascal_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/PA-M-PER-SEC> .
 gistd:_UnitOfMeasure_pascal_meter_per_second skos:prefLabel "pascal meters per second" .
 gistd:_UnitOfMeasure_pascal_meter_per_second skos:scopeNote "1 pascal meters per second = 1.0 x kilogram per secondCubed" .
-gistd:_UnitOfMeasure_pascal_meters gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_pascal_meters gist:isMemberOf gistd:_UnitGroup_energy_or_work_per_area .
-gistd:_UnitOfMeasure_pascal_meters rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_pascal_meters skos:altLabel "pascal meters" .
-gistd:_UnitOfMeasure_pascal_meters skos:closeMatch <http://qudt.org/vocab/unit/PA-M> .
-gistd:_UnitOfMeasure_pascal_meters skos:prefLabel "pascal meters" .
-gistd:_UnitOfMeasure_pascal_meters skos:scopeNote "1 pascal meters = 1.0 x kilogram per secondSquared" .
+gistd:_UnitOfMeasure_pascal_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_pascal_meter gist:isMemberOf gistd:_UnitGroup_energy_or_work_per_area .
+gistd:_UnitOfMeasure_pascal_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_pascal_meter skos:altLabel "pascal meters" .
+gistd:_UnitOfMeasure_pascal_meter skos:closeMatch <http://qudt.org/vocab/unit/PA-M> .
+gistd:_UnitOfMeasure_pascal_meter skos:prefLabel "pascal meters" .
+gistd:_UnitOfMeasure_pascal_meter skos:scopeNote "1 pascal meters = 1.0 x kilogram per secondSquared" .
 gistd:_UnitOfMeasure_pascal_per_bar gist:conversionFactor "0.00001"^^xsd:decimal .
 gistd:_UnitOfMeasure_pascal_per_bar gist:isMemberOf gistd:_UnitGroup_ratio_of_pressures .
 gistd:_UnitOfMeasure_pascal_per_bar rdf:type gist:UnitOfMeasure .
@@ -20389,41 +20389,41 @@ gistd:_UnitOfMeasure_picofarad_per_meter skos:closeMatch <http://qudt.org/vocab/
 gistd:_UnitOfMeasure_picofarad_per_meter skos:definition "from QUDT: 0.000000000001-fold of the SI derived unit farad divided by the SI base unit metre" .
 gistd:_UnitOfMeasure_picofarad_per_meter skos:prefLabel "picofarad per meter" .
 gistd:_UnitOfMeasure_picofarad_per_meter skos:scopeNote "1 picofarad per meter = 0.000000000001 x ampereSquared secondToTheFourth per kilogram meterCubed" .
-gistd:_UnitOfMeasure_picograms gist:conversionFactor "0.000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picograms gist:isMemberOf gistd:_UnitGroup_mass .
-gistd:_UnitOfMeasure_picograms rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picograms skos:altLabel "picograms" .
-gistd:_UnitOfMeasure_picograms skos:closeMatch <http://qudt.org/vocab/unit/PicoGM> .
-gistd:_UnitOfMeasure_picograms skos:prefLabel "picograms" .
-gistd:_UnitOfMeasure_picograms skos:scopeNote "1 picograms = 0.000000000000001 x kilogram" .
-gistd:_UnitOfMeasure_picograms_per_gram gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picograms_per_gram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
-gistd:_UnitOfMeasure_picograms_per_gram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picograms_per_gram skos:altLabel "picograms per gram" .
-gistd:_UnitOfMeasure_picograms_per_gram skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-GM> .
-gistd:_UnitOfMeasure_picograms_per_gram skos:prefLabel "picograms per gram" .
-gistd:_UnitOfMeasure_picograms_per_gram skos:scopeNote "1 picograms per gram = 0.000000000001 x kilogram per kilogram" .
-gistd:_UnitOfMeasure_picograms_per_kilogram gist:conversionFactor "0.000000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picograms_per_kilogram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
-gistd:_UnitOfMeasure_picograms_per_kilogram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picograms_per_kilogram skos:altLabel "picograms per kilogram" .
-gistd:_UnitOfMeasure_picograms_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-KiloGM> .
-gistd:_UnitOfMeasure_picograms_per_kilogram skos:prefLabel "picograms per kilogram" .
-gistd:_UnitOfMeasure_picograms_per_kilogram skos:scopeNote "1 picograms per kilogram = 0.000000000000001 x kilogram per kilogram" .
-gistd:_UnitOfMeasure_picograms_per_liter gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picograms_per_liter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_picograms_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picograms_per_liter skos:altLabel "picograms per liter" .
-gistd:_UnitOfMeasure_picograms_per_liter skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-L> .
-gistd:_UnitOfMeasure_picograms_per_liter skos:prefLabel "picograms per liter" .
-gistd:_UnitOfMeasure_picograms_per_liter skos:scopeNote "1 picograms per liter = 0.000000000001 x kilogram per meterCubed" .
-gistd:_UnitOfMeasure_picograms_per_milliliter gist:conversionFactor "0.000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picograms_per_milliliter gist:isMemberOf gistd:_UnitGroup_mass_density .
-gistd:_UnitOfMeasure_picograms_per_milliliter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picograms_per_milliliter skos:altLabel "picograms per milliliter" .
-gistd:_UnitOfMeasure_picograms_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-MilliL> .
-gistd:_UnitOfMeasure_picograms_per_milliliter skos:prefLabel "picograms per milliliter" .
-gistd:_UnitOfMeasure_picograms_per_milliliter skos:scopeNote "1 picograms per milliliter = 0.000000001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_picogram gist:conversionFactor "0.000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picogram gist:isMemberOf gistd:_UnitGroup_mass .
+gistd:_UnitOfMeasure_picogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picogram skos:altLabel "picograms" .
+gistd:_UnitOfMeasure_picogram skos:closeMatch <http://qudt.org/vocab/unit/PicoGM> .
+gistd:_UnitOfMeasure_picogram skos:prefLabel "picograms" .
+gistd:_UnitOfMeasure_picogram skos:scopeNote "1 picograms = 0.000000000000001 x kilogram" .
+gistd:_UnitOfMeasure_picogram_per_gram gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picogram_per_gram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
+gistd:_UnitOfMeasure_picogram_per_gram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picogram_per_gram skos:altLabel "picograms per gram" .
+gistd:_UnitOfMeasure_picogram_per_gram skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-GM> .
+gistd:_UnitOfMeasure_picogram_per_gram skos:prefLabel "picograms per gram" .
+gistd:_UnitOfMeasure_picogram_per_gram skos:scopeNote "1 picograms per gram = 0.000000000001 x kilogram per kilogram" .
+gistd:_UnitOfMeasure_picogram_per_kilogram gist:conversionFactor "0.000000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picogram_per_kilogram gist:isMemberOf gistd:_UnitGroup_ratio_of_masses .
+gistd:_UnitOfMeasure_picogram_per_kilogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picogram_per_kilogram skos:altLabel "picograms per kilogram" .
+gistd:_UnitOfMeasure_picogram_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-KiloGM> .
+gistd:_UnitOfMeasure_picogram_per_kilogram skos:prefLabel "picograms per kilogram" .
+gistd:_UnitOfMeasure_picogram_per_kilogram skos:scopeNote "1 picograms per kilogram = 0.000000000000001 x kilogram per kilogram" .
+gistd:_UnitOfMeasure_picogram_per_liter gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picogram_per_liter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_picogram_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picogram_per_liter skos:altLabel "picograms per liter" .
+gistd:_UnitOfMeasure_picogram_per_liter skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-L> .
+gistd:_UnitOfMeasure_picogram_per_liter skos:prefLabel "picograms per liter" .
+gistd:_UnitOfMeasure_picogram_per_liter skos:scopeNote "1 picograms per liter = 0.000000000001 x kilogram per meterCubed" .
+gistd:_UnitOfMeasure_picogram_per_milliliter gist:conversionFactor "0.000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picogram_per_milliliter gist:isMemberOf gistd:_UnitGroup_mass_density .
+gistd:_UnitOfMeasure_picogram_per_milliliter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picogram_per_milliliter skos:altLabel "picograms per milliliter" .
+gistd:_UnitOfMeasure_picogram_per_milliliter skos:closeMatch <http://qudt.org/vocab/unit/PicoGM-PER-MilliL> .
+gistd:_UnitOfMeasure_picogram_per_milliliter skos:prefLabel "picograms per milliliter" .
+gistd:_UnitOfMeasure_picogram_per_milliliter skos:scopeNote "1 picograms per milliliter = 0.000000001 x kilogram per meterCubed" .
 gistd:_UnitOfMeasure_picohenry gist:conversionFactor "0.000000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_picohenry gist:isMemberOf gistd:_UnitGroup_inductance .
 gistd:_UnitOfMeasure_picohenry rdf:type gist:UnitOfMeasure .
@@ -20455,48 +20455,48 @@ gistd:_UnitOfMeasure_picomole skos:altLabel "picomoles" .
 gistd:_UnitOfMeasure_picomole skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL> .
 gistd:_UnitOfMeasure_picomole skos:prefLabel "picomole" .
 gistd:_UnitOfMeasure_picomole skos:scopeNote "1 picomole = 0.000000000001 x mole" .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter skos:altLabel "picomoles per cubic meter" .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-M3> .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter skos:prefLabel "picomoles per cubic meter" .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter skos:scopeNote "1 picomoles per cubic meter = 0.000000000001 x mole per meterCubed" .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second skos:altLabel "picomoles per cubic meter per second" .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-M3-SEC> .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second skos:prefLabel "picomoles per cubic meter per second" .
-gistd:_UnitOfMeasure_picomoles_per_cubic_meter_per_second skos:scopeNote "1 picomoles per cubic meter per second = 0.000000000001 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_picomoles_per_kilogram gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picomoles_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
-gistd:_UnitOfMeasure_picomoles_per_kilogram rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picomoles_per_kilogram skos:altLabel "picomoles per kilogram" .
-gistd:_UnitOfMeasure_picomoles_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-KiloGM> .
-gistd:_UnitOfMeasure_picomoles_per_kilogram skos:prefLabel "picomoles per kilogram" .
-gistd:_UnitOfMeasure_picomoles_per_kilogram skos:scopeNote "1 picomoles per kilogram = 0.000000000001 x mole per kilogram" .
-gistd:_UnitOfMeasure_picomoles_per_liter gist:conversionFactor "0.000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picomoles_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
-gistd:_UnitOfMeasure_picomoles_per_liter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picomoles_per_liter skos:altLabel "picomoles per liter" .
-gistd:_UnitOfMeasure_picomoles_per_liter skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-L> .
-gistd:_UnitOfMeasure_picomoles_per_liter skos:prefLabel "picomoles per liter" .
-gistd:_UnitOfMeasure_picomoles_per_liter skos:scopeNote "1 picomoles per liter = 0.000000001 x mole per meterCubed" .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day gist:conversionFactor "0.0000000000000115740740740741"^^xsd:decimal .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day skos:altLabel "picomoles per liter per day" .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-L-DAY> .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day skos:prefLabel "picomoles per liter per day" .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_day skos:scopeNote "1 picomoles per liter per day = 0.0000000000000115740740740741 x mole per meterCubed second" .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour gist:conversionFactor "0.000000000000277777777777778"^^xsd:decimal .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour skos:altLabel "picomoles per liter per hour" .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-L-HR> .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour skos:prefLabel "picomoles per liter per hour" .
-gistd:_UnitOfMeasure_picomoles_per_liter_per_hour skos:scopeNote "1 picomoles per liter per hour = 0.000000000000277777777777778 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter skos:altLabel "picomoles per cubic meter" .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-M3> .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter skos:prefLabel "picomoles per cubic meter" .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter skos:scopeNote "1 picomoles per cubic meter = 0.000000000001 x mole per meterCubed" .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second skos:altLabel "picomoles per cubic meter per second" .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-M3-SEC> .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second skos:prefLabel "picomoles per cubic meter per second" .
+gistd:_UnitOfMeasure_picomole_per_cubic_meter_per_second skos:scopeNote "1 picomoles per cubic meter per second = 0.000000000001 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_picomole_per_kilogram gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picomole_per_kilogram gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_unit_mass .
+gistd:_UnitOfMeasure_picomole_per_kilogram rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picomole_per_kilogram skos:altLabel "picomoles per kilogram" .
+gistd:_UnitOfMeasure_picomole_per_kilogram skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-KiloGM> .
+gistd:_UnitOfMeasure_picomole_per_kilogram skos:prefLabel "picomoles per kilogram" .
+gistd:_UnitOfMeasure_picomole_per_kilogram skos:scopeNote "1 picomoles per kilogram = 0.000000000001 x mole per kilogram" .
+gistd:_UnitOfMeasure_picomole_per_liter gist:conversionFactor "0.000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picomole_per_liter gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume .
+gistd:_UnitOfMeasure_picomole_per_liter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picomole_per_liter skos:altLabel "picomoles per liter" .
+gistd:_UnitOfMeasure_picomole_per_liter skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-L> .
+gistd:_UnitOfMeasure_picomole_per_liter skos:prefLabel "picomoles per liter" .
+gistd:_UnitOfMeasure_picomole_per_liter skos:scopeNote "1 picomoles per liter = 0.000000001 x mole per meterCubed" .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day gist:conversionFactor "0.0000000000000115740740740741"^^xsd:decimal .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day skos:altLabel "picomoles per liter per day" .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-L-DAY> .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day skos:prefLabel "picomoles per liter per day" .
+gistd:_UnitOfMeasure_picomole_per_liter_per_day skos:scopeNote "1 picomoles per liter per day = 0.0000000000000115740740740741 x mole per meterCubed second" .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour gist:conversionFactor "0.000000000000277777777777778"^^xsd:decimal .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour gist:isMemberOf gistd:_UnitGroup_amount_of_substance_per_volume_per_duration .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour skos:altLabel "picomoles per liter per hour" .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour skos:closeMatch <http://qudt.org/vocab/unit/PicoMOL-PER-L-HR> .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour skos:prefLabel "picomoles per liter per hour" .
+gistd:_UnitOfMeasure_picomole_per_liter_per_hour skos:scopeNote "1 picomoles per liter per hour = 0.000000000000277777777777778 x mole per meterCubed second" .
 gistd:_UnitOfMeasure_picopascal gist:conversionFactor "0.000000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_picopascal gist:isMemberOf gistd:_UnitGroup_force_per_area .
 gistd:_UnitOfMeasure_picopascal rdf:type gist:UnitOfMeasure .
@@ -20520,21 +20520,21 @@ gistd:_UnitOfMeasure_picosecond skos:closeMatch <http://qudt.org/vocab/unit/Pico
 gistd:_UnitOfMeasure_picosecond skos:definition "from QUDT: 0.000000000001-fold of the SI base unit second" .
 gistd:_UnitOfMeasure_picosecond skos:prefLabel "picosecond" .
 gistd:_UnitOfMeasure_picosecond skos:scopeNote "1 picosecond = 0.000000000001 x second" .
-gistd:_UnitOfMeasure_picosiemens gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picosiemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_picosiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picosiemens skos:altLabel "picosiemens" .
-gistd:_UnitOfMeasure_picosiemens skos:closeMatch <http://qudt.org/vocab/unit/PicoS> .
-gistd:_UnitOfMeasure_picosiemens skos:prefLabel "picosiemens" .
-gistd:_UnitOfMeasure_picosiemens skos:scopeNote "1 picosiemens = 0.000000000001 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_picosiemens_per_meter gist:conversionFactor "0.000000000001"^^xsd:decimal .
-gistd:_UnitOfMeasure_picosiemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_picosiemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_picosiemens_per_meter skos:altLabel "picosiemens per meter" .
-gistd:_UnitOfMeasure_picosiemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/PicoS-PER-M> .
-gistd:_UnitOfMeasure_picosiemens_per_meter skos:definition "from QUDT: 0.000000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" .
-gistd:_UnitOfMeasure_picosiemens_per_meter skos:prefLabel "picosiemens per meter" .
-gistd:_UnitOfMeasure_picosiemens_per_meter skos:scopeNote "1 picosiemens per meter = 0.000000000001 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_picosiemen gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picosiemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_picosiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picosiemen skos:altLabel "picosiemens" .
+gistd:_UnitOfMeasure_picosiemen skos:closeMatch <http://qudt.org/vocab/unit/PicoS> .
+gistd:_UnitOfMeasure_picosiemen skos:prefLabel "picosiemens" .
+gistd:_UnitOfMeasure_picosiemen skos:scopeNote "1 picosiemens = 0.000000000001 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_picosiemen_per_meter gist:conversionFactor "0.000000000001"^^xsd:decimal .
+gistd:_UnitOfMeasure_picosiemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_picosiemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_picosiemen_per_meter skos:altLabel "picosiemens per meter" .
+gistd:_UnitOfMeasure_picosiemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/PicoS-PER-M> .
+gistd:_UnitOfMeasure_picosiemen_per_meter skos:definition "from QUDT: 0.000000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" .
+gistd:_UnitOfMeasure_picosiemen_per_meter skos:prefLabel "picosiemens per meter" .
+gistd:_UnitOfMeasure_picosiemen_per_meter skos:scopeNote "1 picosiemens per meter = 0.000000000001 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_picowatt gist:conversionFactor "0.000000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_picowatt gist:isMemberOf gistd:_UnitGroup_power .
 gistd:_UnitOfMeasure_picowatt rdf:type gist:UnitOfMeasure .
@@ -21414,14 +21414,14 @@ gistd:_UnitOfMeasure_rayl skos:altLabel "rayls" .
 gistd:_UnitOfMeasure_rayl skos:closeMatch <http://qudt.org/vocab/unit/RAYL> .
 gistd:_UnitOfMeasure_rayl skos:prefLabel "rayl" .
 gistd:_UnitOfMeasure_rayl skos:scopeNote "1 rayl = 1.0 x kilogram per meterSquared second" .
-gistd:_UnitOfMeasure_reads_per_kilobase gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_reads_per_kilobase gist:isMemberOf gistd:_UnitGroup_reads_per_genetic_strand_length .
-gistd:_UnitOfMeasure_reads_per_kilobase rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_reads_per_kilobase rdfs:seeAlso "https://learn.gencore.bio.nyu.edu/metgenomics/shotgun-metagenomics/functional-analysis/"^^xsd:anyURI .
-gistd:_UnitOfMeasure_reads_per_kilobase skos:altLabel "reads per kilobase" .
-gistd:_UnitOfMeasure_reads_per_kilobase skos:closeMatch <http://qudt.org/vocab/unit/RPK> .
-gistd:_UnitOfMeasure_reads_per_kilobase skos:definition "from QUDT: RPK (Reads Per Kilobases) are obtained by dividing read counts by gene lengths (expressed in kilo-nucleotides)." .
-gistd:_UnitOfMeasure_reads_per_kilobase skos:prefLabel "reads per kilobase" .
+gistd:_UnitOfMeasure_read_per_kilobase gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_read_per_kilobase gist:isMemberOf gistd:_UnitGroup_reads_per_genetic_strand_length .
+gistd:_UnitOfMeasure_read_per_kilobase rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_read_per_kilobase rdfs:seeAlso "https://learn.gencore.bio.nyu.edu/metgenomics/shotgun-metagenomics/functional-analysis/"^^xsd:anyURI .
+gistd:_UnitOfMeasure_read_per_kilobase skos:altLabel "reads per kilobase" .
+gistd:_UnitOfMeasure_read_per_kilobase skos:closeMatch <http://qudt.org/vocab/unit/RPK> .
+gistd:_UnitOfMeasure_read_per_kilobase skos:definition "from QUDT: RPK (Reads Per Kilobases) are obtained by dividing read counts by gene lengths (expressed in kilo-nucleotides)." .
+gistd:_UnitOfMeasure_read_per_kilobase skos:prefLabel "reads per kilobase" .
 gistd:_UnitOfMeasure_reciprocal_angstrom gist:conversionFactor "0.0000000001"^^xsd:decimal .
 gistd:_UnitOfMeasure_reciprocal_angstrom gist:isMemberOf gistd:_UnitGroup_inverse_distance .
 gistd:_UnitOfMeasure_reciprocal_angstrom rdf:type gist:UnitOfMeasure .
@@ -21859,13 +21859,13 @@ gistd:_UnitOfMeasure_second_square_foot skos:closeMatch <http://qudt.org/vocab/u
 gistd:_UnitOfMeasure_second_square_foot skos:definition "from QUDT: Is part of the USCS system." .
 gistd:_UnitOfMeasure_second_square_foot skos:prefLabel "second square foot" .
 gistd:_UnitOfMeasure_second_square_foot skos:scopeNote "1 second square foot = 0.09290304 x meterSquared second" .
-gistd:_UnitOfMeasure_seconds_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_seconds_per_meter gist:isMemberOf gistd:_UnitGroup_vapor_permeability .
-gistd:_UnitOfMeasure_seconds_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_seconds_per_meter skos:altLabel "seconds per meter" .
-gistd:_UnitOfMeasure_seconds_per_meter skos:closeMatch <http://qudt.org/vocab/unit/SEC-PER-M> .
-gistd:_UnitOfMeasure_seconds_per_meter skos:prefLabel "seconds per meter" .
-gistd:_UnitOfMeasure_seconds_per_meter skos:scopeNote "1 seconds per meter = 1.0 x second per meter" .
+gistd:_UnitOfMeasure_second_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_second_per_meter gist:isMemberOf gistd:_UnitGroup_vapor_permeability .
+gistd:_UnitOfMeasure_second_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_second_per_meter skos:altLabel "seconds per meter" .
+gistd:_UnitOfMeasure_second_per_meter skos:closeMatch <http://qudt.org/vocab/unit/SEC-PER-M> .
+gistd:_UnitOfMeasure_second_per_meter skos:prefLabel "seconds per meter" .
+gistd:_UnitOfMeasure_second_per_meter skos:scopeNote "1 seconds per meter = 1.0 x second per meter" .
 gistd:_UnitOfMeasure_sextic_meter gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_sextic_meter gist:isMemberOf gistd:_UnitGroup_warping_constant .
 gistd:_UnitOfMeasure_sextic_meter rdf:type gist:UnitOfMeasure .
@@ -21972,39 +21972,39 @@ gistd:_UnitOfMeasure_sidereal_year skos:altLabel "sidereal years" .
 gistd:_UnitOfMeasure_sidereal_year skos:closeMatch <http://qudt.org/vocab/unit/YR_Sidereal> .
 gistd:_UnitOfMeasure_sidereal_year skos:prefLabel "sidereal year" .
 gistd:_UnitOfMeasure_sidereal_year skos:scopeNote "1 sidereal year = 31558149.7632 x second" .
-gistd:_UnitOfMeasure_siemens gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_siemens gist:isMemberOf gistd:_UnitGroup_conductance .
-gistd:_UnitOfMeasure_siemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_siemens rdfs:seeAlso "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI .
-gistd:_UnitOfMeasure_siemens rdfs:seeAlso "https://en.wikipedia.org/wiki/Siemens_(unit)"^^xsd:anyURI .
-gistd:_UnitOfMeasure_siemens skos:altLabel "siemens" .
-gistd:_UnitOfMeasure_siemens skos:closeMatch <http://qudt.org/vocab/unit/S> .
-gistd:_UnitOfMeasure_siemens skos:definition "from QUDT: Is part of the SI system." .
-gistd:_UnitOfMeasure_siemens skos:prefLabel "siemens" .
-gistd:_UnitOfMeasure_siemens skos:scopeNote "1 siemens = 1.0 x ampereSquared secondCubed per kilogram meterSquared" .
-gistd:_UnitOfMeasure_siemens_per_centimeter gist:conversionFactor "100.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_siemens_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_siemens_per_centimeter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_siemens_per_centimeter skos:altLabel "siemens per centimeter" .
-gistd:_UnitOfMeasure_siemens_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/S-PER-CentiM> .
-gistd:_UnitOfMeasure_siemens_per_centimeter skos:definition "from QUDT: SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" .
-gistd:_UnitOfMeasure_siemens_per_centimeter skos:prefLabel "siemens per centimeter" .
-gistd:_UnitOfMeasure_siemens_per_centimeter skos:scopeNote "1 siemens per centimeter = 100.0 x ampereSquared secondCubed per kilogram meterCubed" .
-gistd:_UnitOfMeasure_siemens_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_siemens_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_siemens_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_siemens_per_meter skos:altLabel "siemens per meter" .
-gistd:_UnitOfMeasure_siemens_per_meter skos:closeMatch <http://qudt.org/vocab/unit/S-PER-M> .
-gistd:_UnitOfMeasure_siemens_per_meter skos:definition "from QUDT: SI derived unit siemens divided by the SI base unit metre" .
-gistd:_UnitOfMeasure_siemens_per_meter skos:prefLabel "siemens per meter" .
-gistd:_UnitOfMeasure_siemens_per_meter skos:scopeNote "1 siemens per meter = 1.0 x ampereSquared secondCubed per kilogram meterCubed" .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole gist:isMemberOf gistd:_UnitGroup_molar_conductivity .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole skos:altLabel "siemens square meters per mole" .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole skos:closeMatch <http://qudt.org/vocab/unit/S-M2-PER-MOL> .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole skos:prefLabel "siemen square meter per mole" .
-gistd:_UnitOfMeasure_siemens_square_meter_per_mole skos:scopeNote "1 siemen square meter per mole = 1.0 x ampereSquared secondCubed per kilogram mole" .
+gistd:_UnitOfMeasure_siemen gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_siemen gist:isMemberOf gistd:_UnitGroup_conductance .
+gistd:_UnitOfMeasure_siemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_siemen rdfs:seeAlso "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI .
+gistd:_UnitOfMeasure_siemen rdfs:seeAlso "https://en.wikipedia.org/wiki/Siemens_(unit)"^^xsd:anyURI .
+gistd:_UnitOfMeasure_siemen skos:altLabel "siemens" .
+gistd:_UnitOfMeasure_siemen skos:closeMatch <http://qudt.org/vocab/unit/S> .
+gistd:_UnitOfMeasure_siemen skos:definition "from QUDT: Is part of the SI system." .
+gistd:_UnitOfMeasure_siemen skos:prefLabel "siemens" .
+gistd:_UnitOfMeasure_siemen skos:scopeNote "1 siemens = 1.0 x ampereSquared secondCubed per kilogram meterSquared" .
+gistd:_UnitOfMeasure_siemen_per_centimeter gist:conversionFactor "100.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_siemen_per_centimeter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_siemen_per_centimeter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_siemen_per_centimeter skos:altLabel "siemens per centimeter" .
+gistd:_UnitOfMeasure_siemen_per_centimeter skos:closeMatch <http://qudt.org/vocab/unit/S-PER-CentiM> .
+gistd:_UnitOfMeasure_siemen_per_centimeter skos:definition "from QUDT: SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" .
+gistd:_UnitOfMeasure_siemen_per_centimeter skos:prefLabel "siemens per centimeter" .
+gistd:_UnitOfMeasure_siemen_per_centimeter skos:scopeNote "1 siemens per centimeter = 100.0 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_siemen_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_siemen_per_meter gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_siemen_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_siemen_per_meter skos:altLabel "siemens per meter" .
+gistd:_UnitOfMeasure_siemen_per_meter skos:closeMatch <http://qudt.org/vocab/unit/S-PER-M> .
+gistd:_UnitOfMeasure_siemen_per_meter skos:definition "from QUDT: SI derived unit siemens divided by the SI base unit metre" .
+gistd:_UnitOfMeasure_siemen_per_meter skos:prefLabel "siemens per meter" .
+gistd:_UnitOfMeasure_siemen_per_meter skos:scopeNote "1 siemens per meter = 1.0 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole gist:isMemberOf gistd:_UnitGroup_molar_conductivity .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole skos:altLabel "siemens square meters per mole" .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole skos:closeMatch <http://qudt.org/vocab/unit/S-M2-PER-MOL> .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole skos:prefLabel "siemen square meter per mole" .
+gistd:_UnitOfMeasure_siemen_square_meter_per_mole skos:scopeNote "1 siemen square meter per mole = 1.0 x ampereSquared secondCubed per kilogram mole" .
 gistd:_UnitOfMeasure_sievert gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_sievert gist:isMemberOf gistd:_UnitGroup_dose_equivalent .
 gistd:_UnitOfMeasure_sievert rdf:type gist:UnitOfMeasure .
@@ -22553,16 +22553,16 @@ gistd:_UnitOfMeasure_statohm skos:altLabel "statohms" .
 gistd:_UnitOfMeasure_statohm skos:closeMatch <http://qudt.org/vocab/unit/OHM_Stat> .
 gistd:_UnitOfMeasure_statohm skos:prefLabel "statohm" .
 gistd:_UnitOfMeasure_statohm skos:scopeNote "1 statohm = 898760000000.0 x kilogram meterSquared per ampereSquared secondCubed" .
-gistd:_UnitOfMeasure_statsiemens gist:conversionFactor "0.0000000000011126500561"^^xsd:decimal .
-gistd:_UnitOfMeasure_statsiemens gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
-gistd:_UnitOfMeasure_statsiemens rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_statsiemens rdfs:seeAlso "http://www.knowledgedoor.com/2/units_and_constants_handbook/statsiemens.html"^^xsd:anyURI .
-gistd:_UnitOfMeasure_statsiemens rdfs:seeAlso "http://www.sizes.com/units/statmho.htm"^^xsd:anyURI .
-gistd:_UnitOfMeasure_statsiemens rdfs:seeAlso "http://www3.wolframalpha.com/input/?i=statsiemens"^^xsd:anyURI .
-gistd:_UnitOfMeasure_statsiemens skos:altLabel "statsiemens" .
-gistd:_UnitOfMeasure_statsiemens skos:closeMatch <http://qudt.org/vocab/unit/S_Stat> .
-gistd:_UnitOfMeasure_statsiemens skos:prefLabel "statsiemens" .
-gistd:_UnitOfMeasure_statsiemens skos:scopeNote "1 statsiemens = 0.0000000000011126500561 x ampereSquared secondCubed per kilogram meterCubed" .
+gistd:_UnitOfMeasure_statsiemen gist:conversionFactor "0.0000000000011126500561"^^xsd:decimal .
+gistd:_UnitOfMeasure_statsiemen gist:isMemberOf gistd:_UnitGroup_electric_conductivity .
+gistd:_UnitOfMeasure_statsiemen rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_statsiemen rdfs:seeAlso "http://www.knowledgedoor.com/2/units_and_constants_handbook/statsiemens.html"^^xsd:anyURI .
+gistd:_UnitOfMeasure_statsiemen rdfs:seeAlso "http://www.sizes.com/units/statmho.htm"^^xsd:anyURI .
+gistd:_UnitOfMeasure_statsiemen rdfs:seeAlso "http://www3.wolframalpha.com/input/?i=statsiemens"^^xsd:anyURI .
+gistd:_UnitOfMeasure_statsiemen skos:altLabel "statsiemens" .
+gistd:_UnitOfMeasure_statsiemen skos:closeMatch <http://qudt.org/vocab/unit/S_Stat> .
+gistd:_UnitOfMeasure_statsiemen skos:prefLabel "statsiemens" .
+gistd:_UnitOfMeasure_statsiemen skos:scopeNote "1 statsiemens = 0.0000000000011126500561 x ampereSquared secondCubed per kilogram meterCubed" .
 gistd:_UnitOfMeasure_statvolt gist:conversionFactor "299.792458"^^xsd:decimal .
 gistd:_UnitOfMeasure_statvolt gist:isMemberOf gistd:_UnitGroup_energy_or_work_per_electric_charge .
 gistd:_UnitOfMeasure_statvolt rdf:type gist:UnitOfMeasure .
@@ -23342,13 +23342,13 @@ gistd:_UnitOfMeasure_watt_second skos:closeMatch <http://qudt.org/vocab/unit/W-S
 gistd:_UnitOfMeasure_watt_second skos:definition "from QUDT: product of the SI derived unit watt and SI base unit second" .
 gistd:_UnitOfMeasure_watt_second skos:prefLabel "watt second" .
 gistd:_UnitOfMeasure_watt_second skos:scopeNote "1 watt second = 1.0 x kilogram meterSquared per secondSquared" .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter gist:isMemberOf gistd:_UnitGroup_energy_or_work_per_area .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter skos:altLabel "watt seconds per square meter" .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/W-SEC-PER-M2> .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter skos:prefLabel "watt seconds per square meter" .
-gistd:_UnitOfMeasure_watt_seconds_per_square_meter skos:scopeNote "1 watt seconds per square meter = 1.0 x kilogram per secondSquared" .
+gistd:_UnitOfMeasure_watt_second_per_square_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_watt_second_per_square_meter gist:isMemberOf gistd:_UnitGroup_energy_or_work_per_area .
+gistd:_UnitOfMeasure_watt_second_per_square_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_watt_second_per_square_meter skos:altLabel "watt seconds per square meter" .
+gistd:_UnitOfMeasure_watt_second_per_square_meter skos:closeMatch <http://qudt.org/vocab/unit/W-SEC-PER-M2> .
+gistd:_UnitOfMeasure_watt_second_per_square_meter skos:prefLabel "watt seconds per square meter" .
+gistd:_UnitOfMeasure_watt_second_per_square_meter skos:scopeNote "1 watt seconds per square meter = 1.0 x kilogram per secondSquared" .
 gistd:_UnitOfMeasure_watthour gist:conversionFactor "3600.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_watthour gist:isMemberOf gistd:_UnitGroup_energy_or_work .
 gistd:_UnitOfMeasure_watthour rdf:type gist:UnitOfMeasure .
@@ -23356,20 +23356,20 @@ gistd:_UnitOfMeasure_watthour skos:altLabel "watthours" .
 gistd:_UnitOfMeasure_watthour skos:closeMatch <http://qudt.org/vocab/unit/W-HR> .
 gistd:_UnitOfMeasure_watthour skos:prefLabel "watthour" .
 gistd:_UnitOfMeasure_watthour skos:scopeNote "1 watthour = 3600.0 x kilogram meterSquared per secondSquared" .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter skos:altLabel "watts per square meter per meter" .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter skos:closeMatch <http://qudt.org/vocab/unit/W-PER-M2-M> .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter skos:prefLabel "watts per square meter per meter" .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_meter skos:scopeNote "1 watts per square meter per meter = 1.0 x kilogram per meter secondCubed" .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer gist:conversionFactor "1000000000.0"^^xsd:decimal .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer rdf:type gist:UnitOfMeasure .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer skos:altLabel "watts per square meter per nanometer" .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer skos:closeMatch <http://qudt.org/vocab/unit/W-PER-M2-NanoM> .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer skos:prefLabel "watts per square meter per nanometer" .
-gistd:_UnitOfMeasure_watts_per_square_meter_per_nanometer skos:scopeNote "1 watts per square meter per nanometer = 1000000000.0 x kilogram per meter secondCubed" .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter gist:conversionFactor "1.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter skos:altLabel "watts per square meter per meter" .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter skos:closeMatch <http://qudt.org/vocab/unit/W-PER-M2-M> .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter skos:prefLabel "watts per square meter per meter" .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_meter skos:scopeNote "1 watts per square meter per meter = 1.0 x kilogram per meter secondCubed" .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer gist:conversionFactor "1000000000.0"^^xsd:decimal .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer gist:isMemberOf gistd:_UnitGroup_force_per_area_time .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer rdf:type gist:UnitOfMeasure .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer skos:altLabel "watts per square meter per nanometer" .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer skos:closeMatch <http://qudt.org/vocab/unit/W-PER-M2-NanoM> .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer skos:prefLabel "watts per square meter per nanometer" .
+gistd:_UnitOfMeasure_watt_per_square_meter_per_nanometer skos:scopeNote "1 watts per square meter per nanometer = 1000000000.0 x kilogram per meter secondCubed" .
 gistd:_UnitOfMeasure_weber gist:conversionFactor "1.0"^^xsd:decimal .
 gistd:_UnitOfMeasure_weber gist:isMemberOf gistd:_UnitGroup_magnetic_flux .
 gistd:_UnitOfMeasure_weber rdf:type gist:UnitOfMeasure .


### PR DESCRIPTION
The reference data for units of measure has a mix of singular and plural in IRIs.

Change all plurals to singular, e.g. "watts per hour" would change to "watt per hour".

There is an implied "1" in front of every unit of measure, e.g. 1 watt per hour.

Note that "stokes" is a unit named after a person named Stokes, and is not plural.