### PR TITLE
fix formats of definitions to remove backslashes and some special formatting like "frac" and "textit"

### DIFF
--- a/Data/uomReferenceData.ttl
+++ b/Data/uomReferenceData.ttl
@@ -14,7 +14,7 @@ gistd:_Aspect_absolute_activity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AbsoluteActivity> ;
-	skos:definition 'from QUDT: The "Absolute Activity" is the exponential of the ratio of the chemical potential to \\(RT\\) where \\(R\\) is the gas constant and \\(T\\) the thermodynamic temperature.'^^xsd:string ;
+	skos:definition 'from QUDT: The "Absolute Activity" is the exponential of the ratio of the chemical potential to (RT) where (R) is the gas constant and (T) the thermodynamic temperature.'^^xsd:string ;
 	skos:prefLabel "absolute activity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_absolute_activity ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -28,7 +28,7 @@ gistd:_Aspect_absolute_humidity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AbsoluteHumidity> ;
-	skos:definition 'from QUDT: "Absolute Humidity" is an amount of water vapor, usually discussed per unit volume. Absolute humidity in air ranges from zero to roughly 30 grams per cubic meter when the air is saturated at \\(30 ^\\circ C\\). The absolute humidity changes as air temperature or pressure changes. This is very inconvenient for chemical engineering calculations, e.g. for clothes dryers, where temperature can vary considerably. As a result, absolute humidity is generally defined in chemical engineering as mass of water vapor per unit mass of dry air, also known as the mass mixing ratio, which is much more rigorous for heat and mass balance calculations. Mass of water per unit volume as in the equation above would then be defined as volumetric humidity. Because of the potential confusion.'^^xsd:string ;
+	skos:definition 'from QUDT: "Absolute Humidity" is an amount of water vapor, usually discussed per unit volume. Absolute humidity in air ranges from zero to roughly 30 grams per cubic meter when the air is saturated at (30 ^circ C). The absolute humidity changes as air temperature or pressure changes. This is very inconvenient for chemical engineering calculations, e.g. for clothes dryers, where temperature can vary considerably. As a result, absolute humidity is generally defined in chemical engineering as mass of water vapor per unit mass of dry air, also known as the mass mixing ratio, which is much more rigorous for heat and mass balance calculations. Mass of water per unit volume as in the equation above would then be defined as volumetric humidity. Because of the potential confusion.'^^xsd:string ;
 	skos:prefLabel "absolute humidity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_absolute_humidity ;
 	gist:isCategorizedBy
@@ -45,7 +45,7 @@ gistd:_Aspect_absorbed_dose
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AbsorbedDose> ;
-	skos:definition 'from QUDT: "Absorbed Dose" (also known as Total Ionizing Dose, TID) is a measure of the energy deposited in a medium by ionizing radiation. It is equal to the energy deposited per unit mass of medium, and so has the unit \\(J/kg\\), which is given the special name Gray (\\(Gy\\)).'^^xsd:string ;
+	skos:definition 'from QUDT: "Absorbed Dose" (also known as Total Ionizing Dose, TID) is a measure of the energy deposited in a medium by ionizing radiation. It is equal to the energy deposited per unit mass of medium, and so has the unit (J/kg), which is given the special name Gray ((Gy)).'^^xsd:string ;
 	skos:prefLabel "absorbed dose"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_absorbed_dose ;
 	gist:isCategorizedBy
@@ -92,7 +92,7 @@ gistd:_Aspect_acceleration
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Acceleration"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Acceleration> ;
-	skos:definition "from QUDT: Acceleration is the (instantaneous) rate of change of velocity. Acceleration may be either linear acceleration, or angular acceleration. It is a vector quantity with dimension \\(distance/time^{2}\\) for linear acceleration, or in the case of angular acceleration, with dimension \\(angle/time^{2}\\). In SI units, linear acceleration is measured in \\(meters/second^{2}\\) (\\(m \\cdot s^{-2}\\)) and angular acceleration is measured in \\(radians/second^{2}\\). In physics, any increase or decrease in speed is referred to as acceleration and similarly, motion in a circle at constant speed is also an acceleration, since the direction component of the velocity is changing."^^xsd:string ;
+	skos:definition "from QUDT: Acceleration is the (instantaneous) rate of change of velocity. Acceleration may be either linear acceleration, or angular acceleration. It is a vector quantity with dimension (distance/time^{2}) for linear acceleration, or in the case of angular acceleration, with dimension (angle/time^{2}). In SI units, linear acceleration is measured in (meters/second^{2}) ((m s^{-2})) and angular acceleration is measured in (radians/second^{2}). In physics, any increase or decrease in speed is referred to as acceleration and similarly, motion in a circle at constant speed is also an acceleration, since the direction component of the velocity is changing."^^xsd:string ;
 	skos:prefLabel "acceleration"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_acceleration ;
 	gist:isCategorizedBy gistd:_Discipline_space_and_time ;
@@ -199,7 +199,7 @@ gistd:_Aspect_active_power
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ActivePower> ;
-	skos:definition 'from QUDT: \\(Active Power\\) is, under periodic conditions, the mean value, taken over one period \\(T\\), of the instantaneous power \\(p\\). In complex notation, \\(P = \\mathbf{Re} \\; \\underline{S}\\), where \\(\\underline{S}\\) is \\(\\textit{complex power}\\)".'^^xsd:string ;
+	skos:definition 'from QUDT: (Active Power) is, under periodic conditions, the mean value, taken over one period (T), of the instantaneous power (p). In complex notation, (P = {Real} {S}), where ({S}) is ({complex power})".'^^xsd:string ;
 	skos:prefLabel "active power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_power ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -214,7 +214,7 @@ gistd:_Aspect_activity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Activity> ;
-	skos:definition 'from QUDT: "Activity" is the number of decays per unit time of a radioactive sample, the term used to characterise the number of nuclei which disintegrate in a radioactive substance per unit time. Activity is usually measured in Becquerels (\\(Bq\\)), where 1 \\(Bq\\) is 1 disintegration per second, in honor of the scientist Henri Becquerel.'^^xsd:string ;
+	skos:definition 'from QUDT: "Activity" is the number of decays per unit time of a radioactive sample, the term used to characterise the number of nuclei which disintegrate in a radioactive substance per unit time. Activity is usually measured in Becquerels ((Bq)), where 1 (Bq) is 1 disintegration per second, in honor of the scientist Henri Becquerel.'^^xsd:string ;
 	skos:prefLabel "activity"^^xsd:string ;
 	gist:hasUnitGroup
 		gistd:_UnitGroup_activity ,
@@ -233,7 +233,7 @@ gistd:_Aspect_activity_coefficient
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ActivityCoefficient> ;
-	skos:definition "from QUDT: An \"Activity Coefficient\" is a factor used in thermodynamics to account for deviations from ideal behaviour in a mixture of chemical substances. In an ideal mixture, the interactions between each pair of chemical species are the same (or more formally, the enthalpy change of solution is zero) and, as a result, properties of the mixtures can be expressed directly in terms of simple concentrations or partial pressures of the substances present e.g. Raoult's law. Deviations from ideality are accommodated by modifying the concentration by an activity coefficient. "^^xsd:string ;
+	skos:definition "from QUDT: An Activity Coefficient is a factor used in thermodynamics to account for deviations from ideal behaviour in a mixture of chemical substances. In an ideal mixture, the interactions between each pair of chemical species are the same (or more formally, the enthalpy change of solution is zero) and, as a result, properties of the mixtures can be expressed directly in terms of simple concentrations or partial pressures of the substances present e.g. Raoult's law. Deviations from ideality are accommodated by modifying the concentration by an activity coefficient. "^^xsd:string ;
 	skos:prefLabel "activity coefficient"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -285,7 +285,7 @@ gistd:_Aspect_admittance
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Admittance> ;
-	skos:definition 'from QUDT: "Admittance" is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of the impedance (\\(Z\\)). '^^xsd:string ;
+	skos:definition 'from QUDT: "Admittance" is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of the impedance ((Z)). '^^xsd:string ;
 	skos:prefLabel "admittance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_conductance ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -314,7 +314,7 @@ gistd:_Aspect_alpha_disintegration_energy
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AlphaDisintegrationEnergy> ;
 	skos:definition
-		'from QUDT: The "Alpha Disintegration Energy" is the sum of the kinetic energy of the \\(\\alpha\\)-particle produced in the disintegration process and the recoil energy of the product atom in the reference frame in which the emitting nucleus is at rest before its disintegration.'^^xsd:string ,
+		'from QUDT: The "Alpha Disintegration Energy" is the sum of the kinetic energy of the (alpha)-particle produced in the disintegration process and the recoil energy of the product atom in the reference frame in which the emitting nucleus is at rest before its disintegration.'^^xsd:string ,
 		'from QUDT: The "Alpha Disintegration Energy" is the sum of the kinetic energy of the alpha-particle produced in the disintegration process and the recoil energy of the product atom in the reference frame in which the emitting nucleus is at rest before its disintegration.'^^xsd:string
 		;
 	skos:prefLabel "alpha disintegration energy"^^xsd:string ;
@@ -335,7 +335,7 @@ gistd:_Aspect_ambient_pressure
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AmbientPressure> ;
 	skos:definition """from QUDT: The ambient pressure on an object is the pressure of the surrounding medium, such as a gas or liquid, which comes into contact with the object.
-The SI unit of pressure is the pascal (Pa), which is a very small unit relative to atmospheric pressure on Earth, so kilopascals (\\(kPa\\)) are more commonly used in this context. """^^xsd:string ;
+The SI unit of pressure is the pascal (Pa), which is a very small unit relative to atmospheric pressure on Earth, so kilopascals ((kPa)) are more commonly used in this context. """^^xsd:string ;
 	skos:prefLabel "ambient pressure"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_fluid_pressure ;
 	gist:isCategorizedBy gistd:_Discipline_propulsion ;
@@ -365,7 +365,7 @@ gistd:_Aspect_amount_of_substance
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AmountOfSubstance> ;
-	skos:definition "from QUDT: \"Amount of Substance\" is a standards-defined quantity that measures the size of an ensemble of elementary entities, such as atoms, molecules, electrons, and other particles. It is sometimes referred to as chemical amount. The International System of Units (SI) defines the amount of substance to be proportional to the number of elementary entities present. The SI unit for amount of substance is \\(mole\\). It has the unit symbol \\(mol\\). The mole is defined as the amount of substance that contains an equal number of elementary entities as there are atoms in 0.012kg of the isotope carbon-12. This number is called Avogadro's number and has the value \\(6.02214179(30) \\times 10^{23}\\). The only other unit of amount of substance in current use is the \\(pound-mole\\) with the symbol \\(lb-mol\\), which is sometimes used in chemical engineering in the United States. One \\(pound-mole\\) is exactly \\(453.59237 mol\\)."^^xsd:string ;
+	skos:definition "from QUDT: \"Amount of Substance\" is a standards-defined quantity that measures the size of an ensemble of elementary entities, such as atoms, molecules, electrons, and other particles. It is sometimes referred to as chemical amount. The International System of Units (SI) defines the amount of substance to be proportional to the number of elementary entities present. The SI unit for amount of substance is (mole). It has the unit symbol (mol). The mole is defined as the amount of substance that contains an equal number of elementary entities as there are atoms in 0.012kg of the isotope carbon-12. This number is called Avogadro's number and has the value (6.02214179(30) times 10^{23}). The only other unit of amount of substance in current use is the (pound-mole) with the symbol (lb-mol), which is sometimes used in chemical engineering in the United States. One (pound-mole) is exactly (453.59237 mol)."^^xsd:string ;
 	skos:prefLabel "amount of substance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_amount_of_substance ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -496,7 +496,7 @@ gistd:_Aspect_angle_per_distance
 gistd:_Aspect_angular_acceleration
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AngularAcceleration> ;
-	skos:definition "from QUDT: Angular acceleration is the rate of change of angular velocity over time. Measurement of the change made in the rate of change of an angle that a spinning object undergoes per unit time. It is a vector quantity. Also called Rotational acceleration. In SI units, it is measured in radians per second squared (\\(rad/s^2\\)), and is usually denoted by the Greek letter alpha."^^xsd:string ;
+	skos:definition "from QUDT: Angular acceleration is the rate of change of angular velocity over time. Measurement of the change made in the rate of change of an angle that a spinning object undergoes per unit time. It is a vector quantity. Also called Rotational acceleration. In SI units, it is measured in radians per second squared ((rad/s^2)), and is usually denoted by the Greek letter alpha."^^xsd:string ;
 	skos:prefLabel "angular acceleration"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inverse_square_time ;
 	gist:isCategorizedBy gistd:_Discipline_space_and_time ;
@@ -509,7 +509,7 @@ gistd:_Aspect_angular_cross_section
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AngularCrossSection> ;
-	skos:definition 'from QUDT: "Angular Cross-section" is the cross section for ejecting or scattering a particle into an elementary cone, divided by the solid angle \\(d\\Omega\\) of that cone.'^^xsd:string ;
+	skos:definition 'from QUDT: "Angular Cross-section" is the cross section for ejecting or scattering a particle into an elementary cone, divided by the solid angle (dOmega) of that cone.'^^xsd:string ;
 	skos:prefLabel "angular cross section"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angular_cross_section ;
 	gist:isCategorizedBy
@@ -534,7 +534,7 @@ gistd:_Aspect_angular_frequency
 		"https://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AngularFrequency> ;
-	skos:definition 'from QUDT: "Angular frequency", symbol \\(\\omega\\) (also referred to by the terms angular speed, radial frequency, circular frequency, orbital frequency, radian frequency, and pulsatance) is a scalar measure of rotation rate. Angular frequency (or angular speed) is the magnitude of the vector quantity angular velocity.'^^xsd:string ;
+	skos:definition 'from QUDT: "Angular frequency", symbol (omega) (also referred to by the terms angular speed, radial frequency, circular frequency, orbital frequency, radian frequency, and pulsatance) is a scalar measure of rotation rate. Angular frequency (or angular speed) is the magnitude of the vector quantity angular velocity.'^^xsd:string ;
 	skos:prefLabel "angular frequency"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angular_velocity ;
 	gist:isCategorizedBy
@@ -550,7 +550,7 @@ gistd:_Aspect_angular_impulse
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AngularImpulse> ;
-	skos:definition "from QUDT: The Angular Impulse, also known as angular momentum, is the moment of linear momentum around a point. It is defined as\\(H = \\int Mdt\\), where \\(M\\) is the moment of force and \\(t\\) is time."^^xsd:string ;
+	skos:definition "from QUDT: The Angular Impulse, also known as angular momentum, is the moment of linear momentum around a point. It is defined as(H = int Mdt), where (M) is the moment of force and (t) is time."^^xsd:string ;
 	skos:prefLabel "angular impulse"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angular_momentum ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -563,7 +563,7 @@ gistd:_Aspect_angular_momentum
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AngularMomentum> ;
-	skos:definition "from QUDT: Angular Momentum of an object rotating about some reference point is the measure of the extent to which the object will continue to rotate about that point unless acted upon by an external torque. In particular, if a point mass rotates about an axis, then the angular momentum with respect to a point on the axis is related to the mass of the object, the velocity and the distance of the mass to the axis. While the motion associated with linear momentum has no absolute frame of reference, the rotation associated with angular momentum is sometimes spoken of as being measured relative to the fixed stars. \\textit{Angular Momentum}, \\textit{Moment of Momentum}, or \\textit{Rotational Momentum\", is a vector quantity that represents the product of a body's rotational inertia and rotational velocity about a particular axis."^^xsd:string ;
+	skos:definition "from QUDT: Angular Momentum of an object rotating about some reference point is the measure of the extent to which the object will continue to rotate about that point unless acted upon by an external torque. In particular, if a point mass rotates about an axis, then the angular momentum with respect to a point on the axis is related to the mass of the object, the velocity and the distance of the mass to the axis. While the motion associated with linear momentum has no absolute frame of reference, the rotation associated with angular momentum is sometimes spoken of as being measured relative to the fixed stars. {Angular Momentum}, {Moment of Momentum}, or {Rotational Momentum}, is a vector quantity that represents the product of a body's rotational inertia and rotational velocity about a particular axis."^^xsd:string ;
 	skos:prefLabel "angular momentum"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angular_momentum ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -601,7 +601,7 @@ gistd:_Aspect_angular_wavenumber
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AngularWavenumber> ;
-	skos:definition 'from QUDT: "wavenumber" is the spatial frequency of a wave - the number of waves that exist over a specified distance. More formally, it is the reciprocal of the wavelength. It is also the magnitude of the wave vector.'^^xsd:string ;
+	skos:definition "from QUDT: wavenumber is the spatial frequency of a wave - the number of waves that exist over a specified distance. More formally, it is the reciprocal of the wavelength. It is also the magnitude of the wave vector."^^xsd:string ;
 	skos:prefLabel "angular wavenumber"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inverse_distance ;
 	gist:isCategorizedBy
@@ -618,9 +618,7 @@ gistd:_Aspect_api_gravity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Gravity_API> ;
-	skos:definition """from QUDT: The American Petroleum Institute gravity, or API gravity, is a measure of how heavy or light a petroleum liquid is compared to water: if its API gravity is greater than 10, it is lighter and floats on water; if less than 10, it is heavier and sinks.
-
-API gravity is thus an inverse measure of a petroleum liquid's density relative to that of water (also known as specific gravity). It is used to compare densities of petroleum liquids. For example, if one petroleum liquid is less dense than another, it has a greater API gravity. Although API gravity is mathematically a dimensionless quantity (see the formula below), it is referred to as being in 'degrees'. API gravity is graduated in degrees on a hydrometer instrument. API gravity values of most petroleum liquids fall between 10 and 70 degrees."""^^xsd:string ;
+	skos:definition "from QUDT: The American Petroleum Institute gravity, or API gravity, is a measure of how heavy or light a petroleum liquid is compared to water: if its API gravity is greater than 10, it is lighter and floats on water; if less than 10, it is heavier and sinks.  API gravity is thus an inverse measure of a petroleum liquid's density relative to that of water (also known as specific gravity). It is used to compare densities of petroleum liquids. For example, if one petroleum liquid is less dense than another, it has a greater API gravity. Although API gravity is mathematically a dimensionless quantity (see the formula below), it is referred to as being in degrees. API gravity is graduated in degrees on a hydrometer instrument. API gravity values of most petroleum liquids fall between 10 and 70 degrees."^^xsd:string ;
 	skos:prefLabel "api gravity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -642,7 +640,7 @@ gistd:_Aspect_apparent_power
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ApparentPower> ;
-	skos:definition 'from QUDT: "Apparent Power" is the product of the rms voltage \\(U\\) between the terminals of a two-terminal element or two-terminal circuit and the rms electric current I in the element or circuit. Under sinusoidal conditions, the apparent power is the modulus of the complex power.'^^xsd:string ;
+	skos:definition 'from QUDT: "Apparent Power" is the product of the rms voltage (U) between the terminals of a two-terminal element or two-terminal circuit and the rms electric current I in the element or circuit. Under sinusoidal conditions, the apparent power is the modulus of the complex power.'^^xsd:string ;
 	skos:prefLabel "apparent power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_power ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -727,7 +725,7 @@ gistd:_Aspect_atmospheric_hydroxylation_rate
 gistd:_Aspect_atmospheric_pressure
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/AtmosphericPressure> ;
-	skos:definition "from QUDT: The pressure exerted by the weight of the air above it at any point on the earth's surface. At sea level the atmosphere will support a column of mercury about \\(760 mm\\) high. This decreases with increasing altitude. The standard value for the atmospheric pressure at sea level in SI units is \\(101,325 pascals\\)."^^xsd:string ;
+	skos:definition "from QUDT: The pressure exerted by the weight of the air above it at any point on the earth's surface. At sea level the atmosphere will support a column of mercury about (760 mm) high. This decreases with increasing altitude. The standard value for the atmospheric pressure at sea level in SI units is (101,325 pascals)."^^xsd:string ;
 	skos:prefLabel "atmospheric pressure"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_atmospheric_pressure ;
 	gist:isCategorizedBy gistd:_Discipline_earth_sciences ;
@@ -955,7 +953,7 @@ gistd:_Aspect_blood_glucose_level
 	a gist:Aspect ;
 	rdfs:comment "citation: https://en.wikipedia.org/wiki/Blood_sugar_level"^^xsd:string ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/BloodGlucoseLevel> ;
-	skos:definition "from QUDT: The blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and other animals. Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times. The body tightly regulates blood glucose levels as a part of metabolic homeostasis. Glucose is stored in skeletal muscle and liver cells in the form of glycogen;[2] in fasted individuals, blood glucose is maintained at a constant level at the expense of glycogen stores in the liver and skeletal muscle. [Wikipedia] \\(\\\\\\) There are two main methods of describing concentrations: by weight, and by molecular count. Weights are in grams, molecular counts in moles. A mole is \\(6.022\\times 10^{23}\\) molecules.) In both cases, the unit is usually modified by \\(milli-\\) or \\(micro-\\) or other prefix, and is always \\(per\\) some volume, often a liter. Conversion factors depend on the molecular weight of the substance in question. \\(\\\\\\) \\(mmol/L\\) is millimoles/liter, and is the world standard unit for measuring glucose in blood. Specifically, it is the designated SI (Systeme International) unit. 'World standard' is not universal; not only the US but a number of other countries use mg/dl. A mole is about \\(6\\times 10^{23}\\) molecules. \\(\\\\\\) \\(mg/dL\\) (milligrams/deciliter) is the traditional unit for measuring bG (blood glucose). There is a trend toward using \\(mmol/L\\) however mg/dL is much in practice. Some use is made of \\(mmol/L\\) as the primary unit with \\(mg/dL\\) quoted in parentheses. This acknowledges the large base of health care providers, researchers and patients who are already familiar with \\(mg/dL|)."^^xsd:string ;
+	skos:definition "from QUDT: The blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and other animals. Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times. The body tightly regulates blood glucose levels as a part of metabolic homeostasis. Glucose is stored in skeletal muscle and liver cells in the form of glycogen;[2] in fasted individuals, blood glucose is maintained at a constant level at the expense of glycogen stores in the liver and skeletal muscle. [Wikipedia] () There are two main methods of describing concentrations: by weight, and by molecular count. Weights are in grams, molecular counts in moles. A mole is (6.022times 10^{23}) molecules.) In both cases, the unit is usually modified by (milli-) or (micro-) or other prefix, and is always (per) some volume, often a liter. Conversion factors depend on the molecular weight of the substance in question. () (mmol/L) is millimoles/liter, and is the world standard unit for measuring glucose in blood. Specifically, it is the designated SI (Systeme International) unit. 'World standard' is not universal; not only the US but a number of other countries use mg/dl. A mole is about (6times 10^{23}) molecules. () (mg/dL) (milligrams/deciliter) is the traditional unit for measuring bG (blood glucose). There is a trend toward using (mmol/L) however mg/dL is much in practice. Some use is made of (mmol/L) as the primary unit with (mg/dL) quoted in parentheses. This acknowledges the large base of health care providers, researchers and patients who are already familiar with (mg/dL|)."^^xsd:string ;
 	skos:prefLabel "blood glucose level"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_blood_glucose_level ;
 	gist:isCategorizedBy
@@ -968,7 +966,7 @@ gistd:_Aspect_blood_glucose_level_by_mass
 	a gist:Aspect ;
 	rdfs:comment "citation: https://en.wikipedia.org/wiki/Blood_sugar_level"^^xsd:string ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/BloodGlucoseLevelMass> ;
-	skos:definition "from QUDT: The blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and other animals. Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times. The body tightly regulates blood glucose levels as a part of metabolic homeostasis. Glucose is stored in skeletal muscle and liver cells in the form of glycogen;[2] in fasted individuals, blood glucose is maintained at a constant level at the expense of glycogen stores in the liver and skeletal muscle. [Wikipedia] \\(\\\\\\) There are two main methods of describing concentrations: by weight, and by molecular count. Weights are in grams, molecular counts in moles. A mole is \\(6.022\\times 10^{23}\\) molecules.) In both cases, the unit is usually modified by \\(milli-\\) or \\(micro-\\) or other prefix, and is always \\(per\\) some volume, often a liter. Conversion factors depend on the molecular weight of the substance in question. \\(\\\\\\) \\(mmol/L\\) is millimoles/liter, and is the world standard unit for measuring glucose in blood. Specifically, it is the designated SI (Systeme International) unit. 'World standard' is not universal; not only the US but a number of other countries use mg/dl. A mole is about \\(6\\times 10^{23}\\) molecules. \\(\\\\\\) \\(mg/dL\\) (milligrams/deciliter) is the traditional unit for measuring bG (blood glucose). There is a trend toward using \\(mmol/L\\) however mg/dL is much in practice. Some use is made of \\(mmol/L\\) as the primary unit with \\(mg/dL\\) quoted in parentheses. This acknowledges the large base of health care providers, researchers and patients who are already familiar with \\(mg/dL|)."^^xsd:string ;
+	skos:definition "from QUDT: The blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and other animals. Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times. The body tightly regulates blood glucose levels as a part of metabolic homeostasis. Glucose is stored in skeletal muscle and liver cells in the form of glycogen;[2] in fasted individuals, blood glucose is maintained at a constant level at the expense of glycogen stores in the liver and skeletal muscle. [Wikipedia] () There are two main methods of describing concentrations: by weight, and by molecular count. Weights are in grams, molecular counts in moles. A mole is (6.022times 10^{23}) molecules.) In both cases, the unit is usually modified by (milli-) or (micro-) or other prefix, and is always (per) some volume, often a liter. Conversion factors depend on the molecular weight of the substance in question. () (mmol/L) is millimoles/liter, and is the world standard unit for measuring glucose in blood. Specifically, it is the designated SI (Systeme International) unit. 'World standard' is not universal; not only the US but a number of other countries use mg/dl. A mole is about (6times 10^{23}) molecules. () (mg/dL) (milligrams/deciliter) is the traditional unit for measuring bG (blood glucose). There is a trend toward using (mmol/L) however mg/dL is much in practice. Some use is made of (mmol/L) as the primary unit with (mg/dL) quoted in parentheses. This acknowledges the large base of health care providers, researchers and patients who are already familiar with (mg/dL|)."^^xsd:string ;
 	skos:prefLabel "blood glucose level by mass"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_blood_glucose_level_by_mass ;
 	gist:isCategorizedBy
@@ -992,7 +990,7 @@ gistd:_Aspect_body_mass_index
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.oxfordreference.com/view/10.1093/acref/9780198631477.001.0001/acref-9780198631477-e-254"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/BodyMassIndex> ;
-	skos:definition "from QUDT: \\(\\textit{Body Mass Index}\\), BMI, is an index of weight for height, calculated as: \\(BMI = \\frac{M_{body}}{H^2}\\), where \\(M_{body}\\) is body mass in kg, and \\(H\\) is height in metres. The BMI has been used as a guideline for defining whether a person is overweight because it minimizes the effect of height, but it does not take into consideration other important factors, such as age and body build. The BMI has also been used as an indicator of obesity on the assumption that the higher the index, the greater the level of body fat."^^xsd:string ;
+	skos:definition "from QUDT: ({Body Mass Index}), BMI, is an index of weight for height, calculated as: (BMI = M_body/H^2, where (M_{body}) is body mass in kg, and (H) is height in metres. The BMI has been used as a guideline for defining whether a person is overweight because it minimizes the effect of height, but it does not take into consideration other important factors, such as age and body build. The BMI has also been used as an indicator of obesity on the assumption that the higher the index, the greater the level of body fat."^^xsd:string ;
 	skos:prefLabel "body mass index"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_body_mass_index ;
 	gist:isCategorizedBy gistd:_Discipline_medicine ;
@@ -1149,7 +1147,7 @@ gistd:_Aspect_cash_flow_from_operating_activities
 gistd:_Aspect_catalytic_activity
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/CatalyticActivity> ;
-	skos:definition 'from QUDT: An index of the actual or potential activity of a catalyst. The catalytic activity of an enzyme or an enzyme-containing preparation is defined as the property measured by the increase in the rate of conversion of a specified chemical reaction that the enzyme produces in a specified assay system. Catalytic activity is an extensive quantity and is a property of the enzyme, not of the reaction mixture; it is thus conceptually different from rate of conversion although measured by and equidimensional with it. The unit for catalytic activity is the \\(katal\\); it may also be expressed in mole \\(s^{-1}\\). Dimensions: \\(N T^{-1}\\). Former terms such as catalytic ability, catalytic amount, and enzymic activity are no er recommended. Derived quantities are molar catalytic activity, specific catalytic activity, and catalytic activity concentration. Source(s): <a href="http://www.answers.com/topic/catalytic-activity-biochemistry">www.answers.com</a>'^^xsd:string ;
+	skos:definition 'from QUDT: An index of the actual or potential activity of a catalyst. The catalytic activity of an enzyme or an enzyme-containing preparation is defined as the property measured by the increase in the rate of conversion of a specified chemical reaction that the enzyme produces in a specified assay system. Catalytic activity is an extensive quantity and is a property of the enzyme, not of the reaction mixture; it is thus conceptually different from rate of conversion although measured by and equidimensional with it. The unit for catalytic activity is the (katal); it may also be expressed in mole (s^{-1}). Dimensions: (N T^{-1}). Former terms such as catalytic ability, catalytic amount, and enzymic activity are no er recommended. Derived quantities are molar catalytic activity, specific catalytic activity, and catalytic activity concentration. Source(s): <a href="http://www.answers.com/topic/catalytic-activity-biochemistry">www.answers.com</a>'^^xsd:string ;
 	skos:prefLabel "catalytic activity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_molar_flow_rate ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -1205,7 +1203,7 @@ gistd:_Aspect_characteristic_acoustic_impedance
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Acoustic_impedance#Characteristic_acoustic_impedance"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/CharacteristicAcousticImpedance> ;
-	skos:definition "from QUDT: Characteristic impedance at a point in a non-dissipative medium and for a plane progressive wave, the quotient of the sound pressure \\(p\\) by the component of the sound particle velocity \\(v\\) in the direction of the wave propagation."^^xsd:string ;
+	skos:definition "from QUDT: Characteristic impedance at a point in a non-dissipative medium and for a plane progressive wave, the quotient of the sound pressure (p) by the component of the sound particle velocity (v) in the direction of the wave propagation."^^xsd:string ;
 	skos:prefLabel "characteristic acoustic impedance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_per_area_time ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -1214,7 +1212,7 @@ gistd:_Aspect_characteristic_acoustic_impedance
 gistd:_Aspect_characteristic_velocity
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/CharacteristicVelocity> ;
-	skos:definition "from QUDT: Characteristic velocity or \\(c^{*}\\) is a measure of the combustion performance of a rocket engine independent of nozzle performance, and is used to compare different propellants and propulsion systems."^^xsd:string ;
+	skos:definition "from QUDT: Characteristic velocity or (c^{*}) is a measure of the combustion performance of a rocket engine independent of nozzle performance, and is used to compare different propellants and propulsion systems."^^xsd:string ;
 	skos:prefLabel "characteristic velocity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_speed ;
 	gist:isCategorizedBy gistd:_Discipline_propulsion ;
@@ -1227,7 +1225,7 @@ gistd:_Aspect_charge_number
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ChargeNumber> ;
-	skos:definition "from QUDT: The \"Charge Number\", or just valance of an ion is the coefficient that, when multiplied by the elementary charge, gives the ion's charge."^^xsd:string ;
+	skos:definition "from QUDT: The Charge Number, or just valance of an ion is the coefficient that, when multiplied by the elementary charge, gives the ion's charge."^^xsd:string ;
 	skos:prefLabel "charge number"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_number ;
 	gist:isCategorizedBy
@@ -1293,7 +1291,7 @@ gistd:_Aspect_coefficient_of_heat_transfer
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Heat_transfer_coefficient"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/CoefficientOfHeatTransfer> ;
-	skos:definition 'from QUDT: "Coefficient of Heat Transfer", in thermodynamics and in mechanical and chemical engineering, is used in calculating the heat transfer, typically by convection or phase transition between a fluid and a solid. The heat transfer coefficient is the proportionality coefficient between the heat flux, that is heat flow per unit area, q/A, and the thermodynamic driving force for the flow of heat (that is, the temperature difference, (Delta T). Areic heat flow rate divided by thermodynamic temperature difference. In building technology, the "Coefficient of Heat Transfer", is often called "thermal transmittance}" with the symbol "U". It has SI units in watts per squared meter kelvin.'^^xsd:string ;
+	skos:definition 'from QUDT: Coefficient of Heat Transfer, in thermodynamics and in mechanical and chemical engineering, is used in calculating the heat transfer, typically by convection or phase transition between a fluid and a solid. The heat transfer coefficient is the proportionality coefficient between the heat flux, that is heat flow per unit area, q/A, and the thermodynamic driving force for the flow of heat (that is, the temperature difference, (Delta T). Areic heat flow rate divided by thermodynamic temperature difference. In building technology, the Coefficient of Heat Transfer, is often called thermal transmittance} with the symbol "U". It has SI units in watts per squared meter kelvin.'^^xsd:string ;
 	skos:prefLabel "coefficient of heat transfer"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_coefficient_of_heat_transfer ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -1306,7 +1304,7 @@ gistd:_Aspect_coercivity
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Coercivity> ;
-	skos:definition "from QUDT: \\(\\textit{Coercivity}\\), also referred to as \\(\\textit{Coercive Field Strength}\\), is the magnetic field strength to be applied to bring the magnetic flux density in a substance from its remaining magnetic flux density to zero. This is defined as the coercive field strength in a substance when either the magnetic flux density or the magnetic polarization and magnetization is brought from its value at magnetic saturation to zero by monotonic reduction of the applied magnetic field strength. The quantity which is brought to zero should be stated, and the appropriate symbol used: \\(H_{cB}\\), \\(H_{cJ}\\) or \\(H_{cM}\\) for the coercivity relating to the magnetic flux density, the magnetic polarization or the magnetization respectively, where \\(H_{cJ} = H_{cM}\\)."^^xsd:string ;
+	skos:definition "from QUDT: ({Coercivity}), also referred to as ({Coercive Field Strength}), is the magnetic field strength to be applied to bring the magnetic flux density in a substance from its remaining magnetic flux density to zero. This is defined as the coercive field strength in a substance when either the magnetic flux density or the magnetic polarization and magnetization is brought from its value at magnetic saturation to zero by monotonic reduction of the applied magnetic field strength. The quantity which is brought to zero should be stated, and the appropriate symbol used: (H_{cB}), (H_{cJ}) or (H_{cM}) for the coercivity relating to the magnetic flux density, the magnetic polarization or the magnetization respectively, where (H_{cJ} = H_{cM})."^^xsd:string ;
 	skos:prefLabel "coercivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -1379,7 +1377,7 @@ gistd:_Aspect_complex_power
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ComplexPower> ;
-	skos:definition 'from QUDT: "Complex Power", under sinusoidal conditions, is the product of the phasor \\(U\\) representing the voltage between the terminals of a linear two-terminal element or two-terminal circuit and the complex conjugate of the phasor \\(I\\) representing the electric current in the element or circuit.'^^xsd:string ;
+	skos:definition 'from QUDT: "Complex Power", under sinusoidal conditions, is the product of the phasor (U) representing the voltage between the terminals of a linear two-terminal element or two-terminal circuit and the complex conjugate of the phasor (I) representing the electric current in the element or circuit.'^^xsd:string ;
 	skos:prefLabel "complex power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_power ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -1402,7 +1400,7 @@ gistd:_Aspect_compressibility_factor
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/CompressibilityFactor> ;
-	skos:definition "from QUDT: The compressibility factor (\\(Z\\)) is a useful thermodynamic property for modifying the ideal gas law to account for the real gas behaviour. The closer a gas is to a phase change, the larger the deviations from ideal behavior. It is simply defined as the ratio of the molar volume of a gas to the molar volume of an ideal gas at the same temperature and pressure. Values for compressibility are calculated using equations of state (EOS), such as the virial equation and van der Waals equation. The compressibility factor for specific gases can be obtained, with out calculation, from compressibility charts. These charts are created by plotting Z as a function of pressure at constant temperature."^^xsd:string ;
+	skos:definition "from QUDT: The compressibility factor ((Z)) is a useful thermodynamic property for modifying the ideal gas law to account for the real gas behaviour. The closer a gas is to a phase change, the larger the deviations from ideal behavior. It is simply defined as the ratio of the molar volume of a gas to the molar volume of an ideal gas at the same temperature and pressure. Values for compressibility are calculated using equations of state (EOS), such as the virial equation and van der Waals equation. The compressibility factor for specific gases can be obtained, with out calculation, from compressibility charts. These charts are created by plotting Z as a function of pressure at constant temperature."^^xsd:string ;
 	skos:prefLabel "compressibility factor"^^xsd:string ;
 	gist:hasUnitGroup
 		gistd:_UnitGroup_concentration ,
@@ -1466,7 +1464,7 @@ gistd:_Aspect_conductance
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Conductance> ;
-	skos:definition "from QUDT: \\(\\textit{Conductance}\\), for a resistive two-terminal element or two-terminal circuit with terminals A and B, quotient of the electric current i in the element or circuit by the voltage \\(u_{AB}\\) between the terminals: \\(G = \\frac{1}{R}\\), where the electric current is taken as positive if its direction is from A to B and negative in the opposite case. The conductance of an element or circuit is the inverse of its resistance."^^xsd:string ;
+	skos:definition "from QUDT: ({Conductance}), for a resistive two-terminal element or two-terminal circuit with terminals A and B, quotient of the electric current i in the element or circuit by the voltage (u_{AB}) between the terminals: (G = 1/R), where the electric current is taken as positive if its direction is from A to B and negative in the opposite case. The conductance of an element or circuit is the inverse of its resistance."^^xsd:string ;
 	skos:prefLabel "conductance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_conductance ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -1643,9 +1641,8 @@ gistd:_Aspect_curvature
 		;
 	skos:definition
 		'from QUDT: In mathematics "Curvature" is the amount by which a geometric object deviates from being flat, or straight in the case of a line, but this is defined in different ways depending on the context.'^^xsd:string ,
-		"""from QUDT: The canonical example of extrinsic curvature is that of a circle, which has curvature equal to the inverse of its radius everywhere. Smaller circles bend more sharply, and hence have higher curvature. The curvature of a smooth curve is defined as the curvature of its osculating circle at each point. The osculating circle of a sufficiently smooth plane curve at a given point on the curve is the circle whose center lies on the inner normal line and whose curvature is the same as that of the given curve at that point. This circle is tangent to the curve at the given point.
-That is, given a point P on a smooth curve C, the curvature of C at P is defined to be 1/R where R is the radius of the osculating circle of C at P. The magnitude of curvature at points on physical curves can be measured in diopters (also spelled dioptre) - this is the convention in optics. [Wikipedia],"""^^xsd:string ,
-		"from QUDT: The canonical example of extrinsic curvature is that of a circle, which has curvature equal to the inverse of its radius everywhere. Smaller circles bend more sharply, and hence have higher curvature. The curvature of a smooth curve is defined as the curvature of its osculating circle at each point. The osculating circle of a sufficiently smooth plane curve at a given point on the curve is the circle whose center lies on the inner normal line and whose curvature is the same as that of the given curve at that point. This circle is tangent to the curve at the given point. The magnitude of curvature at points on physical curves can be measured in \\(diopters\\) (also spelled \\(dioptre\\)) - this is the convention in optics."^^xsd:string
+		"from QUDT: The canonical example of extrinsic curvature is that of a circle, which has curvature equal to the inverse of its radius everywhere. Smaller circles bend more sharply, and hence have higher curvature. The curvature of a smooth curve is defined as the curvature of its osculating circle at each point. The osculating circle of a sufficiently smooth plane curve at a given point on the curve is the circle whose center lies on the inner normal line and whose curvature is the same as that of the given curve at that point. This circle is tangent to the curve at the given point. That is, given a point P on a smooth curve C, the curvature of C at P is defined to be 1/R where R is the radius of the osculating circle of C at P. The magnitude of curvature at points on physical curves can be measured in diopters (also spelled dioptre) - this is the convention in optics. [Wikipedia],"^^xsd:string ,
+		"from QUDT: The canonical example of extrinsic curvature is that of a circle, which has curvature equal to the inverse of its radius everywhere. Smaller circles bend more sharply, and hence have higher curvature. The curvature of a smooth curve is defined as the curvature of its osculating circle at each point. The osculating circle of a sufficiently smooth plane curve at a given point on the curve is the circle whose center lies on the inner normal line and whose curvature is the same as that of the given curve at that point. This circle is tangent to the curve at the given point. The magnitude of curvature at points on physical curves can be measured in (diopters) (also spelled (dioptre)) - this is the convention in optics."^^xsd:string
 		;
 	skos:prefLabel "curvature"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inverse_distance ;
@@ -1666,7 +1663,7 @@ gistd:_Aspect_cycle_time
 gistd:_Aspect_data_rate
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DataRate> ;
-	skos:definition 'from QUDT: The frequency derived from the period of time required to transmit one bit. This represents the amount of data transferred per second by a communications channel or a computing or storage device. Data rate is measured in units of bits per second (written "b/s" or "bps"), bytes per second (Bps), or baud. When applied to data rate, the multiplier prefixes "kilo-", "mega-", "giga-", etc. (and their abbreviations, "k", "M", "G", etc.) always denote powers of 1000. For example, 64 kbps is 64,000 bits per second. This contrasts with units of storage which use different prefixes to denote multiplication by powers of 1024, for example 1 kibibit = 1024 bits.'^^xsd:string ;
+	skos:definition "from QUDT: The frequency derived from the period of time required to transmit one bit. This represents the amount of data transferred per second by a communications channel or a computing or storage device. Data rate is measured in units of bits per second (written b/s or bps), bytes per second (Bps), or baud. When applied to data rate, the multiplier prefixes kilo-, mega-, giga-, etc. (and their abbreviations, k, M, G, etc.) always denote powers of 1000. For example, 64 kbps is 64,000 bits per second. This contrasts with units of storage which use different prefixes to denote multiplication by powers of 1024, for example 1 kibibit = 1024 bits."^^xsd:string ;
 	skos:prefLabel "data rate"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_data_rate ;
 	gist:isCategorizedBy
@@ -1802,7 +1799,7 @@ gistd:_Aspect_density
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Density"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Density> ;
-	skos:definition "from QUDT: The mass density or density of a material is defined as its mass per unit volume. The symbol most often used for density is \\(\\rho\\). Mathematically, density is defined as mass divided by volume: \\(\\rho = m/V\\), where \\(\\rho\\) is the density, \\(m\\) is the mass, and \\(V\\) is the volume. In some cases, density is also defined as its weight per unit volume, although this quantity is more properly called specific weight."^^xsd:string ;
+	skos:definition "from QUDT: The mass density or density of a material is defined as its mass per unit volume. The symbol most often used for density is (rho). Mathematically, density is defined as mass divided by volume: (rho = m/V), where (rho) is the density, (m) is the mass, and (V) is the volume. In some cases, density is also defined as its weight per unit volume, although this quantity is more properly called specific weight."^^xsd:string ;
 	skos:prefLabel "density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_density ;
 	gist:isCategorizedBy
@@ -1915,7 +1912,7 @@ gistd:_Aspect_diffusion_coefficient
 		;
 	skos:definition
 		'from QUDT: The "Diffusion Coefficient" is '^^xsd:string ,
-		"from QUDT: The \"Diffusion Coefficient\" is a proportionality constant between the molar flux due to molecular diffusion and the gradient in the concentration of the species (or the driving force for diffusion). Diffusivity is encountered in Fick's law and numerous other equations of physical chemistry."^^xsd:string
+		"from QUDT: The Diffusion Coefficient is a proportionality constant between the molar flux due to molecular diffusion and the gradient in the concentration of the species (or the driving force for diffusion). Diffusivity is encountered in Fick's law and numerous other equations of physical chemistry."^^xsd:string
 		;
 	skos:prefLabel "diffusion coefficient"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_area_per_time ;
@@ -1990,7 +1987,7 @@ gistd:_Aspect_displacement_current
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DisplacementCurrent> ;
-	skos:definition "from QUDT: \"Displacement Current\" is a quantity appearing in Maxwell's equations that is defined in terms of the rate of change of electric displacement field. Displacement current has the units of electric current density, and it has an associated magnetic field just as actual currents do. However it is not an electric current of moving charges, but a time-varying electric field. In materials, there is also a contribution from the slight motion of charges bound in atoms, dielectric polarization."^^xsd:string ;
+	skos:definition "from QUDT: Displacement Current is a quantity appearing in Maxwell's equations that is defined in terms of the rate of change of electric displacement field. Displacement current has the units of electric current density, and it has an associated magnetic field just as actual currents do. However it is not an electric current of moving charges, but a time-varying electric field. In materials, there is also a contribution from the slight motion of charges bound in atoms, dielectric polarization."^^xsd:string ;
 	skos:prefLabel "displacement current"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2003,7 +2000,7 @@ gistd:_Aspect_displacement_current_density
 		"https://www.maxwells-equations.com/math/partial-electric-flux.php"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DisplacementCurrentDensity> ;
-	skos:definition "from QUDT: \\(\\textbf{Displacement Current Density}\\) is the time rate of change of the \\(\\textit{Electric Flux Density}\\). This is a measure of how quickly the electric field changes if we observe it as a function of time. This is different than if we look at how the electric field changes spatially, that is, over a region of space for a fixed amount of time."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Displacement Current Density}) is the time rate of change of the ({Electric Flux Density}). This is a measure of how quickly the electric field changes if we observe it as a function of time. This is different than if we look at how the electric field changes spatially, that is, over a region of space for a fixed amount of time."^^xsd:string ;
 	skos:prefLabel "displacement current density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_current_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2126,7 +2123,7 @@ gistd:_Aspect_dose_equivalent
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DoseEquivalent> ;
-	skos:definition 'from QUDT: "Dose Equivalent} (former), or \\textit{Equivalent Absorbed Radiation Dose}, usually shortened to \\textit{Equivalent Dose", is a computed average measure of the radiation absorbed by a fixed mass of biological tissue, that attempts to account for the different biological damage potential of different types of ionizing radiation. The equivalent dose to a tissue is found by multiplying the absorbed dose, in gray, by a dimensionless "quality factor" \\(Q\\), dependent upon radiation type, and by another dimensionless factor \\(N\\), dependent on all other pertinent factors. N depends upon the part of the body irradiated, the time and volume over which the dose was spread, even the species of the subject.'^^xsd:string ;
+	skos:definition 'from QUDT: Dose Equivalent (former), or {Equivalent Absorbed Radiation Dose}, usually shortened to {Equivalent Dose}, is a computed average measure of the radiation absorbed by a fixed mass of biological tissue, that attempts to account for the different biological damage potential of different types of ionizing radiation. The equivalent dose to a tissue is found by multiplying the absorbed dose, in gray, by a dimensionless "quality factor" (Q), dependent upon radiation type, and by another dimensionless factor (N), dependent on all other pertinent factors. N depends upon the part of the body irradiated, the time and volume over which the dose was spread, even the species of the subject.'^^xsd:string ;
 	skos:prefLabel "dose equivalent"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_dose_equivalent ;
 	gist:isCategorizedBy gistd:_Discipline_radiology ;
@@ -2157,8 +2154,7 @@ gistd:_Aspect_drag_coefficient
 gistd:_Aspect_drag_force
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DragForce> ;
-	skos:definition """from QUDT: In fluid dynamics, drag refers to forces which act on a solid object in the direction of the relative fluid flow velocity. Unlike other resistive forces such as dry friction, which is nearly independent of velocity, drag forces depend on velocity.
-Drag forces always decrease fluid velocity relative to the solid object in the fluid's path."""^^xsd:string ;
+	skos:definition "from QUDT: In fluid dynamics, drag refers to forces which act on a solid object in the direction of the relative fluid flow velocity. Unlike other resistive forces such as dry friction, which is nearly independent of velocity, drag forces depend on velocity. Drag forces always decrease fluid velocity relative to the solid object in the fluid's path."^^xsd:string ;
 	skos:prefLabel "drag force"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_force ;
 	gist:isCategorizedBy gistd:_Discipline_propulsion ;
@@ -2186,7 +2182,7 @@ gistd:_Aspect_dry_volume
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Dry_measure"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DryVolume> ;
-	skos:definition "from QUDT: Dry measures are units of volume used to measure bulk commodities which are not gas or liquid. They are typically used in agriculture, agronomy, and commodity markets to measure grain, dried beans, and dried and fresh fruit; formerly also salt pork and fish. They are also used in fishing for clams, crabs, etc. and formerly for many other substances (for example coal, cement, lime) which were typically shipped and delivered in a standardized container such as a barrel. In the original metric system, the unit of dry volume was the stere, but this is not part of the modern metric system; the liter and the cubic meter (\\(m^{3}\\)) are now used. However, the stere is still widely used for firewood."^^xsd:string ;
+	skos:definition "from QUDT: Dry measures are units of volume used to measure bulk commodities which are not gas or liquid. They are typically used in agriculture, agronomy, and commodity markets to measure grain, dried beans, and dried and fresh fruit; formerly also salt pork and fish. They are also used in fishing for clams, crabs, etc. and formerly for many other substances (for example coal, cement, lime) which were typically shipped and delivered in a standardized container such as a barrel. In the original metric system, the unit of dry volume was the stere, but this is not part of the modern metric system; the liter and the cubic meter ((m^{3})) are now used. However, the stere is still widely used for firewood."^^xsd:string ;
 	skos:prefLabel "dry volume"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_dry_volume ;
 	gist:isCategorizedBy gistd:_Discipline_space_and_time ;
@@ -2230,7 +2226,7 @@ gistd:_Aspect_dynamic_friction_coefficient
 gistd:_Aspect_dynamic_pressure
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/DynamicPressure> ;
-	skos:definition "from QUDT: Dynamic Pressure (indicated with q, or Q, and sometimes called velocity pressure) is the quantity defined by: \\(q = 1/2 * \\rho v^{2}\\), where (using SI units), \\(q\\) is dynamic pressure in \\(pascals\\), \\(\\rho\\) is fluid density in \\(kg/m^{3}\\) (for example, density of air) and \\(v \\) is fluid velocity in \\(m/s\\)."^^xsd:string ;
+	skos:definition "from QUDT: Dynamic Pressure (indicated with q, or Q, and sometimes called velocity pressure) is the quantity defined by: (q = 1/2 * rho v^{2}), where (using SI units), (q) is dynamic pressure in (pascals), (rho) is fluid density in (kg/m^{3}) (for example, density of air) and (v ) is fluid velocity in (m/s)."^^xsd:string ;
 	skos:prefLabel "dynamic pressure"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_fluid_pressure ;
 	gist:isCategorizedBy
@@ -2338,7 +2334,7 @@ gistd:_Aspect_einstein_transition_probability
 	a gist:Aspect ;
 	rdfs:seeAlso "http://electron6.phys.utk.edu/qm2/modules/m10/einstein.htm"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/EinsteinTransitionProbability> ;
-	skos:definition "from QUDT: Given two atomic states of energy \\(E_j\\) and \\(E_k\\). Let \\(E_j > E_k\\). Assume the atom is bathed in radiation of energy density \\(u(w)\\). Transitions between these states can take place in three different ways. Spontaneous, induced/stimulated emission, and induced absorption. \\(A_jk\\) represents the Einstein transition probability for spontaneous emission."^^xsd:string ;
+	skos:definition "from QUDT: Given two atomic states of energy (E_j) and (E_k). Let (E_j > E_k). Assume the atom is bathed in radiation of energy density (u(w)). Transitions between these states can take place in three different ways. Spontaneous, induced/stimulated emission, and induced absorption. (A_jk) represents the Einstein transition probability for spontaneous emission."^^xsd:string ;
 	skos:prefLabel "einstein transition probability"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_probability ;
 	gist:isCategorizedBy gistd:_Discipline_radiometry ;
@@ -2351,7 +2347,7 @@ gistd:_Aspect_electric_charge
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricCharge> ;
-	skos:definition 'from QUDT: "Electric Charge" is a fundamental conserved property of some subatomic particles, which determines their electromagnetic interaction. Electrically charged matter is influenced by, and produces, electromagnetic fields. The electric charge on a body may be positive or negative. Two positively charged bodies experience a mutual repulsive force, as do two negatively charged bodies. A positively charged body and a negatively charged body experience an attractive force. Electric charge is carried by discrete particles and can be positive or negative. The sign convention is such that the elementary electric charge \\(e\\), that is, the charge of the proton, is positive. The SI derived unit of electric charge is the coulomb.'^^xsd:string ;
+	skos:definition 'from QUDT: "Electric Charge" is a fundamental conserved property of some subatomic particles, which determines their electromagnetic interaction. Electrically charged matter is influenced by, and produces, electromagnetic fields. The electric charge on a body may be positive or negative. Two positively charged bodies experience a mutual repulsive force, as do two negatively charged bodies. A positively charged body and a negatively charged body experience an attractive force. Electric charge is carried by discrete particles and can be positive or negative. The sign convention is such that the elementary electric charge (e), that is, the charge of the proton, is positive. The SI derived unit of electric charge is the coulomb.'^^xsd:string ;
 	skos:prefLabel "electric charge"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2381,7 +2377,7 @@ gistd:_Aspect_electric_charge_linear_density
 gistd:_Aspect_electric_charge_per_amount_of_substance
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricChargePerAmountOfSubstance> ;
-	skos:definition 'from QUDT: "Electric Charge Per Amount Of Substance" is the charge assocated with a given amount of substance. Un the ISO and SI systems this is \\(1 mol\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Electric Charge Per Amount Of Substance" is the charge assocated with a given amount of substance. Un the ISO and SI systems this is (1 mol).'^^xsd:string ;
 	skos:prefLabel "electric charge per amount of substance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_charge_per_amount_of_substance ;
 	gist:isCategorizedBy
@@ -2398,7 +2394,7 @@ gistd:_Aspect_electric_charge_per_area
 gistd:_Aspect_electric_charge_per_mass
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricChargePerMass> ;
-	skos:definition 'from QUDT: "Electric Charge Per Mass" is the charge associated with a specific mass of a substance. In the SI and ISO systems this is \\(1 kg\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Electric Charge Per Mass" is the charge associated with a specific mass of a substance. In the SI and ISO systems this is (1 kg).'^^xsd:string ;
 	skos:prefLabel "electric charge per mass"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_charge_per_mass ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2421,7 +2417,7 @@ gistd:_Aspect_electric_charge_volume_density
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricChargeVolumeDensity> ;
-	skos:definition "from QUDT: In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively. The respective SI units are \\(C \\cdot m^{-1}\\), \\(C \\cdot m^{-2}\\) or \\(C \\cdot m^{-3}\\)."^^xsd:string ;
+	skos:definition "from QUDT: In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively. The respective SI units are (C m^{-1}), (C m^{-2}) or (C m^{-3})."^^xsd:string ;
 	skos:prefLabel "electric charge volume density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_charge_volume_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2430,7 +2426,7 @@ gistd:_Aspect_electric_charge_volume_density
 gistd:_Aspect_electric_conductivity
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricConductivity> ;
-	skos:definition "from QUDT: \"Electric Conductivity} or \\textit{Specific Conductance\" is a measure of a material's ability to conduct an electric current. When an electrical potential difference is placed across a conductor, its movable charges flow, giving rise to an electric current. The conductivity \\(\\sigma\\) is defined as the ratio of the electric current density \\(J\\) to the electric field \\(E\\): \\(J = \\sigma E\\). In isotropic materials, conductivity is scalar-valued, however in general, conductivity is a tensor-valued quantity."^^xsd:string ;
+	skos:definition "from QUDT: Electric Conductivity or Specific Conductance is a measure of a material's ability to conduct an electric current. When an electrical potential difference is placed across a conductor, its movable charges flow, giving rise to an electric current. The conductivity (sigma) is defined as the ratio of the electric current density (J) to the electric field (E): (J = sigma E). In isotropic materials, conductivity is scalar-valued, however in general, conductivity is a tensor-valued quantity."^^xsd:string ;
 	skos:prefLabel "electric conductivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_conductivity ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2453,7 +2449,7 @@ gistd:_Aspect_electric_current_density
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricCurrentDensity> ;
-	skos:definition 'from QUDT: "Electric Current Density" is a measure of the density of flow of electric charge; it is the electric current per unit area of cross section. Electric current density is a vector-valued quantity. Electric current, \\(I\\), through a surface \\(S\\) is defined as \\(I = \\int_S J \\cdot e_n dA\\), where \\(e_ndA\\) is the vector surface element.'^^xsd:string ;
+	skos:definition 'from QUDT: "Electric Current Density" is a measure of the density of flow of electric charge; it is the electric current per unit area of cross section. Electric current density is a vector-valued quantity. Electric current, (I), through a surface (S) is defined as (I = int_S J e_n dA), where (e_ndA) is the vector surface element.'^^xsd:string ;
 	skos:prefLabel "electric current density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_current_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2486,7 +2482,7 @@ gistd:_Aspect_electric_current_per_unit_energy
 gistd:_Aspect_electric_current_per_unit_temperature
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricCurrentPerUnitTemperature> ;
-	skos:definition "from QUDT: \"Electric Current per Unit Temperature\" is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature."^^xsd:string ;
+	skos:definition "from QUDT: Electric Current per Unit Temperature is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature."^^xsd:string ;
 	skos:prefLabel "electric current per unit temperature"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_current_per_unit_temperature ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2530,7 +2526,7 @@ gistd:_Aspect_electric_displacement
 		"https://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricDisplacement> ;
-	skos:definition "from QUDT: In a dielectric material the presence of an electric field E causes the bound charges in the material (atomic nuclei and their electrons) to slightly separate, inducing a local electric dipole moment. The Electric Displacement Field, \\(D\\), is a vector field that accounts for the effects of free charges within such dielectric materials. This describes also the charge density on an extended surface that could be causing the field."^^xsd:string ;
+	skos:definition "from QUDT: In a dielectric material the presence of an electric field E causes the bound charges in the material (atomic nuclei and their electrons) to slightly separate, inducing a local electric dipole moment. The Electric Displacement Field, (D), is a vector field that accounts for the effects of free charges within such dielectric materials. This describes also the charge density on an extended surface that could be causing the field."^^xsd:string ;
 	skos:prefLabel "electric displacement"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_charge_surface_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2560,7 +2556,7 @@ gistd:_Aspect_electric_field_strength
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricFieldStrength> ;
-	skos:definition "from QUDT: \\(\\textbf{Electric Field Strength}\\) is the magnitude and direction of an electric field, expressed by the value of \\(E\\), also referred to as \\(\\color{indigo} {\\textit{electric field intensity}}\\) or simply the electric field."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Electric Field Strength}) is the magnitude and direction of an electric field, expressed by the value of (E), also referred to as (color{indigo} {{electric field intensity}}) or simply the electric field."^^xsd:string ;
 	skos:prefLabel "electric field strength"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_field_strength ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2580,7 +2576,7 @@ gistd:_Aspect_electric_flux_density
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricFluxDensity> ;
-	skos:definition "from QUDT: \\(\\textbf{Electric Flux Density}\\), also referred to as \\(\\textit{Electric Displacement}\\), is related to electric charge density by the following equation: \\(\\text{div} \\; D = \\rho\\), where \\(\\text{div}\\) denotes the divergence."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Electric Flux Density}), also referred to as ({Electric Displacement}), is related to electric charge density by the following equation: (text{div} ; D = rho), where (text{div}) denotes the divergence."^^xsd:string ;
 	skos:prefLabel "electric flux density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_charge_surface_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2619,7 +2615,7 @@ gistd:_Aspect_electric_potential
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricPotential> ;
-	skos:definition "from QUDT: The Electric Potential is a scalar valued quantity associated with an electric field. The electric potential \\(\\phi(x)\\) at a point, \\(x\\), is formally defined as the line integral of the electric field taken along a path from x to the point at infinity. If the electric field is static, that is time independent, then the choice of the path is arbitrary; however if the electric field is time dependent, taking the integral a different paths will produce different results."^^xsd:string ;
+	skos:definition "from QUDT: The Electric Potential is a scalar valued quantity associated with an electric field. The electric potential (phi(x)) at a point, (x), is formally defined as the line integral of the electric field taken along a path from x to the point at infinity. If the electric field is static, that is time independent, then the choice of the path is arbitrary; however if the electric field is time dependent, taking the integral a different paths will produce different results."^^xsd:string ;
 	skos:prefLabel "electric potential"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2638,7 +2634,7 @@ gistd:_Aspect_electric_potential_difference
 gistd:_Aspect_electric_power
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectricPower> ;
-	skos:definition 'from QUDT: "Electric Power" is the rate at which electrical energy is transferred by an electric circuit. In the simple case of direct current circuits, electric power can be calculated as the product of the potential difference in the circuit (V) and the amount of current flowing in the circuit (I): \\(P = VI\\), where \\(P\\) is the power, \\(V\\) is the potential difference, and \\(I\\) is the current. However, in general electric power is calculated by taking the integral of the vector cross-product of the electrical and magnetic fields over a specified area.'^^xsd:string ;
+	skos:definition 'from QUDT: "Electric Power" is the rate at which electrical energy is transferred by an electric circuit. In the simple case of direct current circuits, electric power can be calculated as the product of the potential difference in the circuit (V) and the amount of current flowing in the circuit (I): (P = VI), where (P) is the power, (V) is the potential difference, and (I) is the current. However, in general electric power is calculated by taking the integral of the vector cross-product of the electrical and magnetic fields over a specified area.'^^xsd:string ;
 	skos:prefLabel "electric power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_power ;
 	gist:isCategorizedBy
@@ -2676,7 +2672,7 @@ gistd:_Aspect_electric_reactance
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Reactance> ;
-	skos:definition "from QUDT: \"Reactance\" is the opposition of a circuit element to a change of electric current or voltage, due to that element's inductance or capacitance. A built-up electric field resists the change of voltage on the element, while a magnetic field resists the change of current. The notion of reactance is similar to electrical resistance, but they differ in several respects. Capacitance and inductance are inherent properties of an element, just like resistance."^^xsd:string ;
+	skos:definition "from QUDT: Reactance is the opposition of a circuit element to a change of electric current or voltage, due to that element's inductance or capacitance. A built-up electric field resists the change of voltage on the element, while a magnetic field resists the change of current. The notion of reactance is similar to electrical resistance, but they differ in several respects. Capacitance and inductance are inherent properties of an element, just like resistance."^^xsd:string ;
 	skos:prefLabel "electric reactance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_resistance ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2747,7 +2743,7 @@ gistd:_Aspect_electromagnetic_energy_density
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectromagneticEnergyDensity> ;
-	skos:definition "from QUDT: \\(\\textbf{Electromagnetic Energy Density}\\), also known as the \\(\\color{indigo} {\\textit{Volumic Electromagnetic Energy}}\\), is the energy associated with an electromagnetic field, per unit volume of the field."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Electromagnetic Energy Density}), also known as the (color{indigo} {{Volumic Electromagnetic Energy}}), is the energy associated with an electromagnetic field, per unit volume of the field."^^xsd:string ;
 	skos:prefLabel "electromagnetic energy density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2779,7 +2775,7 @@ gistd:_Aspect_electromagnetic_wave_phase_speed
 gistd:_Aspect_electromotive_force
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ElectromotiveForce> ;
-	skos:definition 'from QUDT: In physics, electromotive force, or most commonly \\(emf\\) (seldom capitalized), or (occasionally) electromotance is that which tends to cause current (actual electrons and ions) to flow. More formally, \\(emf\\) is the external work expended per unit of charge to produce an electric potential difference across two open-circuited terminals. "Electromotive Force" is deprecated in the ISO System of Quantities.'^^xsd:string ;
+	skos:definition 'from QUDT: In physics, electromotive force, or most commonly (emf) (seldom capitalized), or (occasionally) electromotance is that which tends to cause current (actual electrons and ions) to flow. More formally, (emf) is the external work expended per unit of charge to produce an electric potential difference across two open-circuited terminals. "Electromotive Force" is deprecated in the ISO System of Quantities.'^^xsd:string ;
 	skos:prefLabel "electromotive force"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -2866,7 +2862,7 @@ gistd:_Aspect_emissivity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Emissivity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Emissivity> ;
-	skos:definition "from QUDT: Emissivity of a material (usually written \\(\\varepsilon\\) or e) is the relative ability of its surface to emit energy by radiation."^^xsd:string ;
+	skos:definition "from QUDT: Emissivity of a material (usually written (varepsilon) or e) is the relative ability of its surface to emit energy by radiation."^^xsd:string ;
 	skos:prefLabel "emissivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_radiometry ;
@@ -2916,8 +2912,7 @@ gistd:_Aspect_energy_expenditure
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.oxfordreference.com/view/10.1093/acref/9780198631477.001.0001/acref-9780198631477-e-594"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/EnergyExpenditure> ;
-	skos:definition """from QUDT: Energy expenditure is dependent on a person's sex, metabolic rate, body-mass composition, the thermic effects of food, and activity level. The approximate energy expenditure of a man lying in bed is \\(1.0\\,kilo\\,calorie\\,per\\,hour\\,per\\,kilogram\\). For slow walking (just over two miles per hour), \\(3.0\\,kilo\\,calorie\\,per\\,hour\\,per\\,kilogram\\). For fast steady running (about 10 miles per hour), \\(16.3\\,kilo\\,calorie\\,per\\,hour\\,per\\,kilogram\\).
-Females expend about 10 per cent less energy than males of the same size doing a comparable activity. For people weighing the same, individuals with a high percentage of body fat usually expend less energy than lean people, because fat is not as metabolically active as muscle."""^^xsd:string ;
+	skos:definition "from QUDT: Energy expenditure is dependent on a person's sex, metabolic rate, body-mass composition, the thermic effects of food, and activity level. The approximate energy expenditure of a man lying in bed is (1.0,kilo,calorie,per,hour,per,kilogram). For slow walking (just over two miles per hour), (3.0,kilo,calorie,per,hour,per,kilogram). For fast steady running (about 10 miles per hour), (16.3,kilo,calorie,per,hour,per,kilogram).  Females expend about 10 per cent less energy than males of the same size doing a comparable activity. For people weighing the same, individuals with a high percentage of body fat usually expend less energy than lean people, because fat is not as metabolically active as muscle."^^xsd:string ;
 	skos:prefLabel "energy expenditure"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_power ;
 	gist:isCategorizedBy
@@ -2998,7 +2993,7 @@ gistd:_Aspect_energy_per_electric_charge
 	a gist:Aspect ;
 	rdfs:seeAlso "https://physics.about.com/od/glossary/g/voltage.htm"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/EnergyPerElectricCharge> ;
-	skos:definition "from QUDT: Voltage is a representation of the electric potential energy per unit charge. If a unit of electrical charge were placed in a location, the voltage indicates the potential energy of it at that point. In other words, it is a measurement of the energy contained within an electric field, or an electric circuit, at a given point. Voltage is a scalar quantity. The SI unit of voltage is the volt, such that \\(1 volt = 1 joule/coulomb\\)."^^xsd:string ;
+	skos:definition "from QUDT: Voltage is a representation of the electric potential energy per unit charge. If a unit of electrical charge were placed in a location, the voltage indicates the potential energy of it at that point. In other words, it is a measurement of the energy contained within an electric field, or an electric circuit, at a given point. Voltage is a scalar quantity. The SI unit of voltage is the volt, such that (1 volt = 1 joule/coulomb)."^^xsd:string ;
 	skos:prefLabel "energy per electric charge"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -3041,7 +3036,7 @@ gistd:_Aspect_enthalpy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Enthalpy> ;
-	skos:definition "from QUDT: In thermodynamics, \\(\\textit{enthalpy}\\) is the sum of the internal energy \\(U\\) and the product of pressure \\(p\\) and volume \\(V\\) of a system. The characteristic function (also known as thermodynamic potential) \\(\\textit{enthalpy}\\) used to be called \\(\\textit{heat content}\\), which is why it is conventionally indicated by \\(H\\). The specific enthalpy of a working mass is a property of that mass used in thermodynamics, defined as \\(h=u+p \\cdot v\\), where \\(u\\) is the specific internal energy, \\(p\\) is the pressure, and \\(v\\) is specific volume. In other words, \\(h = H / m\\) where \\(m\\) is the mass of the system. The SI unit for \\(\\textit{Specific Enthalpy}\\) is \\(\\textit{joules per kilogram}\\)"^^xsd:string ;
+	skos:definition "from QUDT: In thermodynamics, ({enthalpy}) is the sum of the internal energy (U) and the product of pressure (p) and volume (V) of a system. The characteristic function (also known as thermodynamic potential) ({enthalpy}) used to be called ({heat content}), which is why it is conventionally indicated by (H). The specific enthalpy of a working mass is a property of that mass used in thermodynamics, defined as (h=u+p v), where (u) is the specific internal energy, (p) is the pressure, and (v) is specific volume. In other words, (h = H / m) where (m) is the mass of the system. The SI unit for ({Specific Enthalpy}) is ({joules per kilogram})"^^xsd:string ;
 	skos:prefLabel "enthalpy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3051,7 +3046,7 @@ gistd:_Aspect_entropy
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Entropy> ;
-	skos:definition "from QUDT: When a small amount of heat \\(dQ\\) is received by a system whose thermodynamic temperature is \\(T\\), the entropy of the system increases by \\(dQ/T\\), provided that no irreversible change takes place in the system."^^xsd:string ;
+	skos:definition "from QUDT: When a small amount of heat (dQ) is received by a system whose thermodynamic temperature is (T), the entropy of the system increases by (dQ/T), provided that no irreversible change takes place in the system."^^xsd:string ;
 	skos:prefLabel "entropy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_temperature ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3409,7 +3404,7 @@ gistd:_Aspect_force
 		"https://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Force> ;
-	skos:definition "from QUDT: \"Force\" is an influence that causes mass to accelerate. It may be experienced as a lift, a push, or a pull. Force is defined by Newton's Second Law as \\(F = m \\times a \\), where \\(F\\) is force, \\(m\\) is mass and \\(a\\) is acceleration. Net force is mathematically equal to the time rate of change of the momentum of the body on which it acts. Since momentum is a vector quantity (has both a magnitude and direction), force also is a vector quantity."^^xsd:string ;
+	skos:definition "from QUDT: Force is an influence that causes mass to accelerate. It may be experienced as a lift, a push, or a pull. Force is defined by Newton's Second Law as (F = m times a ), where (F) is force, (m) is mass and (a) is acceleration. Net force is mathematically equal to the time rate of change of the momentum of the body on which it acts. Since momentum is a vector quantity (has both a magnitude and direction), force also is a vector quantity."^^xsd:string ;
 	skos:prefLabel "force"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_force ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -3459,7 +3454,7 @@ gistd:_Aspect_force_per_electric_charge
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Electric_field"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ForcePerElectricCharge> ;
-	skos:definition "from QUDT: The electric field depicts the force exerted on other electrically charged objects by the electrically charged particle the field is surrounding. The electric field is a vector field with SI units of newtons per coulomb (\\(N C^{-1}\\)) or, equivalently, volts per metre (\\(V m^{-1}\\) ). The SI base units of the electric field are \\(kg m s^{-3} A^{-1}\\). The strength or magnitude of the field at a given point is defined as the force that would be exerted on a positive test charge of 1 coulomb placed at that point"^^xsd:string ;
+	skos:definition "from QUDT: The electric field depicts the force exerted on other electrically charged objects by the electrically charged particle the field is surrounding. The electric field is a vector field with SI units of newtons per coulomb ((N C^{-1})) or, equivalently, volts per metre ((V m^{-1}) ). The SI base units of the electric field are (kg m s^{-3} A^{-1}). The strength or magnitude of the field at a given point is defined as the force that would be exerted on a positive test charge of 1 coulomb placed at that point"^^xsd:string ;
 	skos:prefLabel "force per electric charge"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_field_strength ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -3484,7 +3479,7 @@ gistd:_Aspect_fractional_mass_stages_1_through_3
 gistd:_Aspect_frequency
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Frequency> ;
-	skos:definition 'from QUDT: "Frequency" is the number of occurrences of a repeating event per unit time. The repetition of the events may be periodic (that is. the length of time between event repetitions is fixed) or aperiodic (i.e. the length of time between event repetitions varies). Therefore, we distinguish between periodic and aperiodic frequencies. In the SI system, periodic frequency is measured in hertz (Hz) or multiples of hertz, while aperiodic frequency is measured in becquerel (Bq). In spectroscopy, \\(\\nu\\) is mostly used. Light passing through different media keeps its frequency, but not its wavelength or wavenumber.'^^xsd:string ;
+	skos:definition 'from QUDT: "Frequency" is the number of occurrences of a repeating event per unit time. The repetition of the events may be periodic (that is. the length of time between event repetitions is fixed) or aperiodic (i.e. the length of time between event repetitions varies). Therefore, we distinguish between periodic and aperiodic frequencies. In the SI system, periodic frequency is measured in hertz (Hz) or multiples of hertz, while aperiodic frequency is measured in becquerel (Bq). In spectroscopy, (nu) is mostly used. Light passing through different media keeps its frequency, but not its wavelength or wavenumber.'^^xsd:string ;
 	skos:prefLabel "frequency"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_frequency ;
 	gist:isCategorizedBy
@@ -3668,7 +3663,7 @@ gistd:_Aspect_gibbs_energy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/GibbsEnergy> ;
-	skos:definition 'from QUDT: "Gibbs Energy} is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. \\textit{Internal Energy} is the internal energy of the system, \\textit{Enthalpy} is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name \\textit{Gibbs Free Energy" is also used.'^^xsd:string ;
+	skos:definition 'from QUDT: "Gibbs Energy} is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. {Internal Energy} is the internal energy of the system, {Enthalpy} is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name {Gibbs Free Energy" is also used.'^^xsd:string ;
 	skos:prefLabel "gibbs energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3754,7 +3749,7 @@ gistd:_Aspect_gyromagnetic_ratio
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Gyromagnetic_ratio"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/GyromagneticRatio> ;
-	skos:definition 'from QUDT: "Gyromagnetic Ratio}, also sometimes known as the magnetogyric ratio in other disciplines, of a particle or system is the ratio of its magnetic dipole moment to its angular momentum, and it is often denoted by the symbol, \\(\\gamma\\). Its SI units are radian per second per tesla (\\(rad s^{-1} \\cdot T^{1}\\)) or, equivalently, coulomb per kilogram (\\(C \\cdot kg^{-1"\\)).'^^xsd:string ;
+	skos:definition 'from QUDT: "Gyromagnetic Ratio}, also sometimes known as the magnetogyric ratio in other disciplines, of a particle or system is the ratio of its magnetic dipole moment to its angular momentum, and it is often denoted by the symbol, (gamma). Its SI units are radian per second per tesla ((rad s^{-1} T^{1})) or, equivalently, coulomb per kilogram ((C kg^{-1")).'^^xsd:string ;
 	skos:prefLabel "gyromagnetic ratio"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_area_moment ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -3847,7 +3842,7 @@ gistd:_Aspect_heat_capacity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Heat_capacity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/HeatCapacity> ;
-	skos:definition "from QUDT: \"Heat Capacity\" (usually denoted by a capital \\(C\\), often with subscripts), or thermal capacity, is the measurable physical quantity that characterizes the amount of heat required to change a substance's temperature by a given amount. In the International System of Units (SI), heat capacity is expressed in units of joule(s) (J) per kelvin (K)."^^xsd:string ;
+	skos:definition "from QUDT: Heat Capacity (usually denoted by a capital (C), often with subscripts), or thermal capacity, is the measurable physical quantity that characterizes the amount of heat required to change a substance's temperature by a given amount. In the International System of Units (SI), heat capacity is expressed in units of joule(s) (J) per kelvin (K)."^^xsd:string ;
 	skos:prefLabel "heat capacity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_temperature ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3860,7 +3855,7 @@ gistd:_Aspect_heat_capacity_ratio
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/HeatCapacityRatio> ;
-	skos:definition "from QUDT: The heat capacity ratio, or ratio of specific heats, is the ratio of the heat capacity at constant pressure (\\(C_P\\)) to heat capacity at constant volume (\\(C_V\\)). For an ideal gas, the heat capacity is constant with temperature (\\(\\theta\\)). Accordingly we can express the enthalpy as \\(H = C_P*\\theta\\) and the internal energy as \\(U = C_V \\cdot \\theta\\). Thus, it can also be said that the heat capacity ratio is the ratio between enthalpy and internal energy."^^xsd:string ;
+	skos:definition "from QUDT: The heat capacity ratio, or ratio of specific heats, is the ratio of the heat capacity at constant pressure ((C_P)) to heat capacity at constant volume ((C_V)). For an ideal gas, the heat capacity is constant with temperature ((theta)). Accordingly we can express the enthalpy as (H = C_P*theta) and the internal energy as (U = C_V theta). Thus, it can also be said that the heat capacity ratio is the ratio between enthalpy and internal energy."^^xsd:string ;
 	skos:prefLabel "heat capacity ratio"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3870,7 +3865,7 @@ gistd:_Aspect_heat_flow_rate
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Rate_of_heat_flow"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/HeatFlowRate> ;
-	skos:definition "from QUDT: The rate of heat flow between two systems is measured in watts (joules per second). The formula for rate of heat flow is \\(\\bigtriangleup Q / \\bigtriangleup t = -K \\times A \\times \\bigtriangleup T/x\\), where \\(\\bigtriangleup Q / \\bigtriangleup t\\) is the rate of heat flow; \\(-K\\) is the thermal conductivity factor; A is the surface area; \\(\\bigtriangleup T\\) is the change in temperature and \\(x\\) is the thickness of the material. \\(\\bigtriangleup T/ x\\) is called the temperature gradient and is always negative because of the heat of flow always goes from more thermal energy to less)."^^xsd:string ;
+	skos:definition "from QUDT: The rate of heat flow between two systems is measured in watts (joules per second). The formula for rate of heat flow is (bigtriangleup Q / bigtriangleup t = -K times A times bigtriangleup T/x), where (bigtriangleup Q / bigtriangleup t) is the rate of heat flow; (-K) is the thermal conductivity factor; A is the surface area; (bigtriangleup T) is the change in temperature and (x) is the thickness of the material. (bigtriangleup T/ x) is called the temperature gradient and is always negative because of the heat of flow always goes from more thermal energy to less)."^^xsd:string ;
 	skos:prefLabel "heat flow rate"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_heat_flow_rate ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3883,7 +3878,7 @@ gistd:_Aspect_heat_flow_rate_per_area
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/HeatFlowRatePerUnitArea> ;
-	skos:definition "from QUDT: \\(\\textit{Heat Flux}\\) is the heat rate per unit area. In SI units, heat flux is measured in \\(W/m^2\\). Heat rate is a scalar quantity, while heat flux is a vectorial quantity. To define the heat flux at a certain point in space, one takes the limiting case where the size of the surface becomes infinitesimally small."^^xsd:string ;
+	skos:definition "from QUDT: ({Heat Flux}) is the heat rate per unit area. In SI units, heat flux is measured in (W/m^2). Heat rate is a scalar quantity, while heat flux is a vectorial quantity. To define the heat flux at a certain point in space, one takes the limiting case where the size of the surface becomes infinitesimally small."^^xsd:string ;
 	skos:prefLabel "heat flow rate per unit area"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_power_per_area ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -3943,7 +3938,7 @@ gistd:_Aspect_height
 		"https://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Height> ;
-	skos:definition 'from QUDT: "Height" is the measurement of vertical distance, but has two meanings in common use. It can either indicate how "tall" something is, or how "high up" it is.'^^xsd:string ;
+	skos:definition 'from QUDT: Height is the measurement of vertical distance, but has two meanings in common use. It can either indicate how tall something is, or how "high up" it is.'^^xsd:string ;
 	skos:prefLabel "height"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_distance ;
 	gist:isCategorizedBy
@@ -3959,7 +3954,7 @@ gistd:_Aspect_helmholtz_energy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/HelmholtzEnergy> ;
-	skos:definition "from QUDT: \\(\\textit{Helmholtz Energy}\\) is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. \\(\\textit{Internal Energy}\\) is the internal energy of the system, \\(\\textit{Enthalpy}\\) is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name \\(\\textit{Helmholz Free Energy}\\) is also used."^^xsd:string ;
+	skos:definition "from QUDT: ({Helmholtz Energy}) is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. ({Internal Energy}) is the internal energy of the system, ({Enthalpy}) is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name ({Helmholz Free Energy}) is also used."^^xsd:string ;
 	skos:prefLabel "helmholtz energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -4042,7 +4037,7 @@ gistd:_Aspect_illuminance
 		;
 	skos:definition
 		"from QUDT: Illuminance is the total luminous flux incident on a surface, per unit area. It is a measure of the intensity of the incident light, wavelength-weighted by the luminosity function to correlate with human brightness perception."^^xsd:string ,
-		"from QUDT: Spherical illuminance is equal to quotient of the total luminous flux \\(\\Phi_v\\) incident on a small sphere by the cross section area of that sphere."^^xsd:string
+		"from QUDT: Spherical illuminance is equal to quotient of the total luminous flux (Phi_v) incident on a small sphere by the cross section area of that sphere."^^xsd:string
 		;
 	skos:prefLabel "illuminance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_luminous_flux_per_area ;
@@ -4113,7 +4108,7 @@ gistd:_Aspect_inductance
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Inductance> ;
-	skos:definition "from QUDT: \"Inductance\" is an electromagentic quantity that characterizes a circuit's resistance to any change of electric current; a change in the electric current through induces an opposing electromotive force (EMF). Quantitatively, inductance is proportional to the magnetic flux per unit of electric current."^^xsd:string ;
+	skos:definition "from QUDT: Inductance is an electromagentic quantity that characterizes a circuit's resistance to any change of electric current; a change in the electric current through induces an opposing electromotive force (EMF). Quantitatively, inductance is proportional to the magnetic flux per unit of electric current."^^xsd:string ;
 	skos:prefLabel "inductance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inductance ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -4211,7 +4206,7 @@ gistd:_Aspect_instantaneous_power
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/InstantaneousPower> ;
-	skos:definition 'from QUDT: "Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage \\(u_{AB}\\) between the terminals and the electric current i in the element or circuit: \\(p = \\)u_{AB} \\cdot i\\(, where \\)u_{AB" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case. For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs. For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element. For a polyphase line consisting of m line conductors and one neutral conductor, it is the sum of the m instantaneous powers expressed for each line conductor by the product of the polyphase line-to-neutral voltage and the corresponding line current.'^^xsd:string ;
+	skos:definition 'from QUDT: "Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage (u_{AB}) between the terminals and the electric current i in the element or circuit: (p = )u_{AB} i(, where )u_{AB" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case. For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs. For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element. For a polyphase line consisting of m line conductors and one neutral conductor, it is the sum of the m instantaneous powers expressed for each line conductor by the product of the polyphase line-to-neutral voltage and the corresponding line current.'^^xsd:string ;
 	skos:prefLabel "instantaneous power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_power ;
 	gist:isCategorizedBy
@@ -4236,8 +4231,8 @@ gistd:_Aspect_internal_energy
 		<http://qudt.org/vocab/quantitykind/InternalEnergy>
 		;
 	skos:definition
-		'from QUDT: "Internal Energy" is simply its energy. "internal" refers to the fact that some energy contributions are not considered. For instance, when the total system is in uniform motion, it has kinetic energy. This overall kinetic energy is never seen as part of the internal energy; one could call it external energy. Or, if the system is at constant non-zero height above the surface the Earth, it has constant potential energy in the gravitational field of the Earth. Gravitational energy is only taken into account when it plays a role in the phenomenon of interest, for instance in a colloidal suspension, where the gravitation influences the up- downward motion of the small particles comprising the colloid. In all other cases, gravitational energy is assumed not to contribute to the internal energy; one may call it again external energy.'^^xsd:string ,
-		"from QUDT: The internal energy is the total energy contained by a thermodynamic system. It is the energy needed to create the system, but excludes the energy to displace the system's surroundings, any energy associated with a move as a whole, or due to external force fields. Internal energy has two major components, kinetic energy and potential energy. The internal energy (U) is the sum of all forms of energy (Ei) intrinsic to a thermodynamic system: \\( U = \\sum_i E_i \\)"^^xsd:string
+		'from QUDT: Internal Energy is simply its energy. "internal" refers to the fact that some energy contributions are not considered. For instance, when the total system is in uniform motion, it has kinetic energy. This overall kinetic energy is never seen as part of the internal energy; one could call it external energy. Or, if the system is at constant non-zero height above the surface the Earth, it has constant potential energy in the gravitational field of the Earth. Gravitational energy is only taken into account when it plays a role in the phenomenon of interest, for instance in a colloidal suspension, where the gravitation influences the up- downward motion of the small particles comprising the colloid. In all other cases, gravitational energy is assumed not to contribute to the internal energy; one may call it again external energy.'^^xsd:string ,
+		"from QUDT: The internal energy is the total energy contained by a thermodynamic system. It is the energy needed to create the system, but excludes the energy to displace the system's surroundings, any energy associated with a move as a whole, or due to external force fields. Internal energy has two major components, kinetic energy and potential energy. The internal energy (U) is the sum of all forms of energy (Ei) intrinsic to a thermodynamic system: ( U = sum_i E_i )"^^xsd:string
 		;
 	skos:prefLabel "internal energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work ;
@@ -4282,7 +4277,7 @@ gistd:_Aspect_inverse_distance
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Reciprocal_length"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/InverseLength> ;
-	skos:definition "from QUDT: Reciprocal length or inverse length is a measurement used in several branches of science and mathematics. As the reciprocal of length, common units used for this measurement include the reciprocal metre or inverse metre (\\(m^{-1}\\)), the reciprocal centimetre or inverse centimetre (\\(cm^{-1}\\)), and, in optics, the dioptre."^^xsd:string ;
+	skos:definition "from QUDT: Reciprocal length or inverse length is a measurement used in several branches of science and mathematics. As the reciprocal of length, common units used for this measurement include the reciprocal metre or inverse metre ((m^{-1})), the reciprocal centimetre or inverse centimetre ((cm^{-1})), and, in optics, the dioptre."^^xsd:string ;
 	skos:prefLabel "inverse length"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inverse_distance ;
 	gist:isCategorizedBy gistd:_Discipline_space_and_time ;
@@ -4502,7 +4497,7 @@ gistd:_Aspect_irradiance
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Irradiance"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Irradiance> ;
-	skos:definition 'from QUDT: Irradiance and Radiant Emittance are radiometry terms for the power per unit area of electromagnetic radiation at a surface. "Irradiance" is used when the electromagnetic radiation is incident on the surface. "Radiant emittance" (or "radiant exitance") is used when the radiation is emerging from the surface.'^^xsd:string ;
+	skos:definition "from QUDT: Irradiance and Radiant Emittance are radiometry terms for the power per unit area of electromagnetic radiation at a surface. Irradiance is used when the electromagnetic radiation is incident on the surface. Radiant emittance (or radiant exitance) is used when the radiation is emerging from the surface."^^xsd:string ;
 	skos:prefLabel "irradiance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_power_per_area ;
 	gist:isCategorizedBy
@@ -4532,7 +4527,7 @@ gistd:_Aspect_isentropic_exponent
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/IsentropicExponent> ;
-	skos:definition 'from QUDT: Isentropic exponent is a variant of "Specific Heat Ratio Capacities}. For an ideal gas \\textit{Isentropic Exponent"\\(, \\varkappa\\). is equal to \\(\\gamma\\), the ratio of its specific heat capacities \\(c_p\\) and \\(c_v\\) under steady pressure and volume.'^^xsd:string ;
+	skos:definition 'from QUDT: Isentropic exponent is a variant of "Specific Heat Ratio Capacities}. For an ideal gas {Isentropic Exponent"(, varkappa). is equal to (gamma), the ratio of its specific heat capacities (c_p) and (c_v) under steady pressure and volume.'^^xsd:string ;
 	skos:prefLabel "isentropic exponent"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -4591,7 +4586,7 @@ gistd:_Aspect_kinematic_viscosity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/KinematicViscosity> ;
-	skos:definition "from QUDT: The ratio of the viscosity of a liquid to its density. Viscosity is a measure of the resistance of a fluid which is being deformed by either shear stress or tensile stress. In many situations, we are concerned with the ratio of the inertial force to the viscous force (that is the Reynolds number), the former characterized by the fluid density \\(\\rho\\). This ratio is characterized by the kinematic viscosity (Greek letter \\(\\nu\\)), defined as follows: \\(\\nu = \\mu / \\rho\\). The SI unit of \\(\\nu\\) is \\(m^{2}/s\\). The SI unit of \\(\\nu\\) is \\(kg/m^{1}\\)."^^xsd:string ;
+	skos:definition "from QUDT: The ratio of the viscosity of a liquid to its density. Viscosity is a measure of the resistance of a fluid which is being deformed by either shear stress or tensile stress. In many situations, we are concerned with the ratio of the inertial force to the viscous force (that is the Reynolds number), the former characterized by the fluid density (rho). This ratio is characterized by the kinematic viscosity (Greek letter (nu)), defined as follows: (nu = mu / rho). The SI unit of (nu) is (m^{2}/s). The SI unit of (nu) is (kg/m^{1})."^^xsd:string ;
 	skos:prefLabel "kinematic viscosity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_area_per_time ;
 	gist:isCategorizedBy gistd:_Discipline_fluid_dynamics ;
@@ -4608,8 +4603,8 @@ gistd:_Aspect_kinetic_energy
 		<http://qudt.org/vocab/quantitykind/KineticEnergy>
 		;
 	skos:definition
-		"from QUDT: The kinetic energy of an object is the energy which it possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to its stated velocity."^^xsd:string ,
-		"from QUDT: \\(\\textit{Kinetic Energy}\\) is the energy which a body possesses as a consequence of its motion, defined as one-half the product of its mass \\(m\\) and the square of its speed \\(v\\), \\( \\frac{1}{2} mv^{2} \\). The kinetic energy per unit volume of a fluid parcel is the \\( \\frac{1}{2} p v^{2}\\) , where \\(p\\) is the density and \\(v\\) the speed of the parcel. See potential energy. For relativistic speeds the kinetic energy is given by \\(E_k = mc^2 - m_0 c^2\\), where \\(c\\) is the velocity of light in a vacuum, \\(m_0\\) is the rest mass, and \\(m\\) is the moving mass."^^xsd:string
+		"from QUDT: ({Kinetic Energy}) is the energy which a body possesses as a consequence of its motion, defined as one-half the product of its mass (m) and the square of its speed (v), ( 1/2 mv^{2} ). The kinetic energy per unit volume of a fluid parcel is the ( 1/2 p v^{2}) , where (p) is the density and (v) the speed of the parcel. See potential energy. For relativistic speeds the kinetic energy is given by (E_k = mc^2 - m_0 c^2), where (c) is the velocity of light in a vacuum, (m_0) is the rest mass, and (m) is the moving mass."^^xsd:string ,
+		"from QUDT: The kinetic energy of an object is the energy which it possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to its stated velocity."^^xsd:string
 		;
 	skos:prefLabel "kinetic energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work ;
@@ -4852,7 +4847,7 @@ gistd:_Aspect_linear_electric_current_density
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/LinearElectricCurrentDensity> ;
-	skos:definition 'from QUDT: "Linear Electric Linear Current Density" is the electric current per unit length. Electric current, \\(I\\), through a curve \\(C\\) is defined as \\(I = \\int_C J _s \\times e_n\\), where \\(e_n\\) is a unit vector perpendicular to the surface and line vector element, and \\(dr\\) is the differential of position vector \\(r\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Linear Electric Linear Current Density" is the electric current per unit length. Electric current, (I), through a curve (C) is defined as (I = int_C J _s times e_n), where (e_n) is a unit vector perpendicular to the surface and line vector element, and (dr) is the differential of position vector (r).'^^xsd:string ;
 	skos:prefLabel "linear electric current density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -4912,7 +4907,7 @@ gistd:_Aspect_linear_momentum
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Momentum"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/LinearMomentum> ;
-	skos:definition "from QUDT: Linear momentum is the quantity obtained by multiplying the mass of a body by its linear velocity. The momentum of a continuous medium is given by the integral of the velocity over the mass of the medium or by the product of the total mass of the medium and the velocity of the center of gravity of the medium.The SI unit for linear momentum is meter-kilogram per second (\\(m-kg/s\\))."^^xsd:string ;
+	skos:definition "from QUDT: Linear momentum is the quantity obtained by multiplying the mass of a body by its linear velocity. The momentum of a continuous medium is given by the integral of the velocity over the mass of the medium or by the product of the total mass of the medium and the velocity of the center of gravity of the medium.The SI unit for linear momentum is meter-kilogram per second ((m-kg/s))."^^xsd:string ;
 	skos:prefLabel "linear momentum"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_momentum ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -4945,7 +4940,7 @@ gistd:_Aspect_linear_velocity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://au.answers.yahoo.com/question/index?qid=20080319082534AAtrClv"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/LinearVelocity> ;
-	skos:definition "from QUDT: Linear Velocity, as the name implies deals with speed in a straight line, the units are often \\(km/hr\\) or \\(m/s\\) or \\(mph\\) (miles per hour). Linear Velocity (v) = change in distance/change in time, where \\(v = \\bigtriangleup d/\\bigtriangleup t\\)"^^xsd:string ;
+	skos:definition "from QUDT: Linear Velocity, as the name implies deals with speed in a straight line, the units are often (km/hr) or (m/s) or (mph) (miles per hour). Linear Velocity (v) = change in distance/change in time, where (v = bigtriangleup d/bigtriangleup t)"^^xsd:string ;
 	skos:prefLabel "linear velocity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_speed ;
 	gist:isCategorizedBy gistd:_Discipline_space_and_time ;
@@ -4959,7 +4954,7 @@ gistd:_Aspect_linked_flux
 		"https://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-1800"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/LinkedFlux> ;
-	skos:definition 'from QUDT: "Linked Flux" is defined as the path integral of the magnetic vector potential. This is the line integral of a magnetic vector potential \\(A\\) along a curve \\(C\\). The line vector element \\(dr\\) is the differential of position vector \\(r\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Linked Flux" is defined as the path integral of the magnetic vector potential. This is the line integral of a magnetic vector potential (A) along a curve (C). The line vector element (dr) is the differential of position vector (r).'^^xsd:string ;
 	skos:prefLabel "linked flux"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_flux ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5055,7 +5050,7 @@ gistd:_Aspect_loss_factor
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/LossFactor> ;
-	skos:definition 'from QUDT: "Loss Factor} is the inverse of \\textit{Quality Factor} and is the ratio of the \\textit{resistance} and modulus of \\textit{reactance".'^^xsd:string ;
+	skos:definition 'from QUDT: "Loss Factor} is the inverse of {Quality Factor} and is the ratio of the {resistance} and modulus of {reactance".'^^xsd:string ;
 	skos:prefLabel "loss factor"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_number ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5141,7 +5136,7 @@ gistd:_Aspect_luminous_flux_per_area
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Illuminance"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/LuminousFluxPerArea> ;
-	skos:definition "from QUDT: In photometry, illuminance is the total luminous flux incident on a surface, per unit area. It is a measure of how much the incident light illuminates the surface, wavelength-weighted by the luminosity function to correlate with human brightness perception. Similarly, luminous emittance is the luminous flux per unit area emitted from a surface. In SI derived units these are measured in \\(lux (lx)\\) or \\(lumens per square metre\\) (\\(cd \\cdot m^{-2}\\)). In the CGS system, the unit of illuminance is the \\(phot\\), which is equal to \\(10,000 lux\\). The \\(foot-candle\\) is a non-metric unit of illuminance that is used in photography."^^xsd:string ;
+	skos:definition "from QUDT: In photometry, illuminance is the total luminous flux incident on a surface, per unit area. It is a measure of how much the incident light illuminates the surface, wavelength-weighted by the luminosity function to correlate with human brightness perception. Similarly, luminous emittance is the luminous flux per unit area emitted from a surface. In SI derived units these are measured in (lux (lx)) or (lumens per square metre) ((cd m^{-2})). In the CGS system, the unit of illuminance is the (phot), which is equal to (10,000 lux). The (foot-candle) is a non-metric unit of illuminance that is used in photography."^^xsd:string ;
 	skos:prefLabel "luminous flux per area"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_luminous_flux_per_area ;
 	gist:isCategorizedBy gistd:_Discipline_optics ;
@@ -5236,7 +5231,7 @@ gistd:_Aspect_magnetic_area_moment
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticAreaMoment> ;
-	skos:definition 'from QUDT: "Magnetic Area Moment", for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. "Magnetic Area Moment" is also referred to as "Magnetic Moment".'^^xsd:string ;
+	skos:definition 'from QUDT: Magnetic Area Moment, for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. Magnetic Area Moment is also referred to as "Magnetic Moment".'^^xsd:string ;
 	skos:prefLabel "magnetic area moment"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_area_moment ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5252,7 +5247,7 @@ gistd:_Aspect_magnetic_dipole_moment
 		"https://www.simetric.co.uk/siderived.htm"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticDipoleMoment> ;
-	skos:definition "from QUDT: \"Magnetic Dipole Moment\" is the magnetic moment of a system is a measure of the magnitude and the direction of its magnetism. Magnetic moment usually refers to its Magnetic Dipole Moment, and quantifies the contribution of the system's internal magnetism to the external dipolar magnetic field produced by the system (that is, the component of the external magnetic field that is inversely proportional to the cube of the distance to the observer). The Magnetic Dipole Moment is a vector-valued quantity. For a particle or nucleus, vector quantity causing an increment \\(\\Delta W = -\\mu \\cdot B\\) to its energy \\(W\\) in an external magnetic field with magnetic flux density \\(B\\)."^^xsd:string ;
+	skos:definition "from QUDT: Magnetic Dipole Moment is the magnetic moment of a system is a measure of the magnitude and the direction of its magnetism. Magnetic moment usually refers to its Magnetic Dipole Moment, and quantifies the contribution of the system's internal magnetism to the external dipolar magnetic field produced by the system (that is, the component of the external magnetic field that is inversely proportional to the cube of the distance to the observer). The Magnetic Dipole Moment is a vector-valued quantity. For a particle or nucleus, vector quantity causing an increment (Delta W = -mu B) to its energy (W) in an external magnetic field with magnetic flux density (B)."^^xsd:string ;
 	skos:prefLabel "magnetic dipole moment"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_dipole_moment ;
 	gist:isCategorizedBy
@@ -5264,7 +5259,7 @@ gistd:_Aspect_magnetic_dipole_moment
 gistd:_Aspect_magnetic_field
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticField> ;
-	skos:definition "from QUDT: The Magnetic Field, denoted \\(B\\), is a fundamental field in electrodynamics which characterizes the magnetic force exerted by electric currents. It is closely related to the auxillary magnetic field H (see quantitykind:AuxillaryMagneticField)."^^xsd:string ;
+	skos:definition "from QUDT: The Magnetic Field, denoted (B), is a fundamental field in electrodynamics which characterizes the magnetic force exerted by electric currents. It is closely related to the auxillary magnetic field H (see quantitykind:AuxillaryMagneticField)."^^xsd:string ;
 	skos:prefLabel "magnetic field"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_flux_density ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5277,7 +5272,7 @@ gistd:_Aspect_magnetic_field_strength
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticFieldStrength_H> ;
-	skos:definition "from QUDT: \\(\\textbf{Magnetic Field Strength}\\) is a vector quantity obtained at a given point by subtracting the magnetization \\(M\\) from the magnetic flux density \\(B\\) divided by the magnetic constant \\(\\mu_0\\). The magnetic field strength is related to the total current density \\(J_{tot}\\) via: \\(\\text{rot} H = J_{tot}\\)."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Magnetic Field Strength}) is a vector quantity obtained at a given point by subtracting the magnetization (M) from the magnetic flux density (B) divided by the magnetic constant (mu_0). The magnetic field strength is related to the total current density (J_{tot}) via: (text{rot} H = J_{tot})."^^xsd:string ;
 	skos:prefLabel "magnetic field strength"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5303,7 +5298,7 @@ gistd:_Aspect_magnetic_flux_density
 		"https://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-1798"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticFluxDensity> ;
-	skos:definition 'from QUDT: "Magnetic Flux Density" is a vector quantity and is the magnetic flux per unit area of a magnetic field at right angles to the magnetic force. It can be defined in terms of the effects the field has, for example by \\(B = F/q v \\sin \\theta\\), where \\(F\\) is the force a moving charge \\(q\\) would experience if it was travelling at a velocity \\(v\\) in a direction making an angle θ with that of the field. The magnetic field strength is also a vector quantity and is related to \\(B\\) by: \\(H = B/\\mu\\), where \\(\\mu\\) is the permeability of the medium.'^^xsd:string ;
+	skos:definition 'from QUDT: "Magnetic Flux Density" is a vector quantity and is the magnetic flux per unit area of a magnetic field at right angles to the magnetic force. It can be defined in terms of the effects the field has, for example by (B = F/q v sin theta), where (F) is the force a moving charge (q) would experience if it was travelling at a velocity (v) in a direction making an angle θ with that of the field. The magnetic field strength is also a vector quantity and is related to (B) by: (H = B/mu), where (mu) is the permeability of the medium.'^^xsd:string ;
 	skos:prefLabel "magnetic flux density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_flux_density ;
 	gist:isCategorizedBy
@@ -5329,7 +5324,7 @@ gistd:_Aspect_magnetic_moment
 		"https://www.simetric.co.uk/siderived.htm"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticMoment> ;
-	skos:definition 'from QUDT: "Magnetic Moment", for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. "Magnetic Moment" is also referred to as "Magnetic Area Moment", and is not to be confused with Magnetic Dipole Moment.'^^xsd:string ;
+	skos:definition "from QUDT: Magnetic Moment, for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. Magnetic Moment is also referred to as Magnetic Area Moment, and is not to be confused with Magnetic Dipole Moment."^^xsd:string ;
 	skos:prefLabel "magnetic moment"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_area_moment ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5342,7 +5337,7 @@ gistd:_Aspect_magnetic_polarization
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticPolarization> ;
-	skos:definition "from QUDT: \\(\\textbf{Magnetic Polarization}\\) is a vector quantity equal to the product of the magnetization \\(M\\) and the magnetic constant \\(\\mu_0\\)."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Magnetic Polarization}) is a vector quantity equal to the product of the magnetization (M) and the magnetic constant (mu_0)."^^xsd:string ;
 	skos:prefLabel "magnetic polarization"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5355,7 +5350,7 @@ gistd:_Aspect_magnetic_quantum_number
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticQuantumNumber> ;
-	skos:definition 'from QUDT: The "Magnetic Quantum Number" describes the specific orbital (or "cloud") within that subshell, and yields the projection of the orbital angular momentum along a specified axis.'^^xsd:string ;
+	skos:definition "from QUDT: The Magnetic Quantum Number describes the specific orbital (or cloud) within that subshell, and yields the projection of the orbital angular momentum along a specified axis."^^xsd:string ;
 	skos:prefLabel "magnetic quantum number"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_quantum_number ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -5365,7 +5360,7 @@ gistd:_Aspect_magnetic_reluctivity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Permeability_(electromagnetism)"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticReluctivity> ;
-	skos:definition 'from QUDT: "Length Per Unit Magnetic Flux} is the the resistance of a material to the establishment of a magnetic field in it. It is the reciprocal of \\textit{Magnetic Permeability", the inverse of the measure of the ability of a material to support the formation of a magnetic field within itself.'^^xsd:string ;
+	skos:definition 'from QUDT: "Length Per Unit Magnetic Flux} is the the resistance of a material to the establishment of a magnetic field in it. It is the reciprocal of {Magnetic Permeability", the inverse of the measure of the ability of a material to support the formation of a magnetic field within itself.'^^xsd:string ;
 	skos:prefLabel "magnetic reluctivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_reluctivity ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5382,7 +5377,7 @@ gistd:_Aspect_magnetic_susceptibility
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticSusceptability> ;
-	skos:definition 'from QUDT: "Magnetic Susceptability" is a scalar or tensor quantity the product of which by the magnetic constant \\(\\mu_0\\) and by the magnetic field strength \\(H\\) is equal to the magnetic polarization \\(J\\). The definition given applies to an isotropic medium. For an anisotropic medium permeability is a second order tensor.'^^xsd:string ;
+	skos:definition 'from QUDT: "Magnetic Susceptability" is a scalar or tensor quantity the product of which by the magnetic constant (mu_0) and by the magnetic field strength (H) is equal to the magnetic polarization (J). The definition given applies to an isotropic medium. For an anisotropic medium permeability is a second order tensor.'^^xsd:string ;
 	skos:prefLabel "magnetic susceptibility"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_magnetic_susceptibility ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5395,7 +5390,7 @@ gistd:_Aspect_magnetic_tension
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagneticTension> ;
-	skos:definition 'from QUDT: "Magnetic Tension} is a scalar quantity equal to the line integral of the magnetic field strength \\mathbf{H" along a specified path linking two points a and b.'^^xsd:string ;
+	skos:definition 'from QUDT: "Magnetic Tension} is a scalar quantity equal to the line integral of the magnetic field strength mathbf{H" along a specified path linking two points a and b.'^^xsd:string ;
 	skos:prefLabel "magnetic tension"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5434,7 +5429,7 @@ gistd:_Aspect_magnetomotive_force
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MagnetomotiveForce> ;
-	skos:definition "from QUDT: \\(\\textbf{Magnetomotive Force}\\) (\\(mmf\\)) is the ability of an electric circuit to produce magnetic flux. Just as the ability of a battery to produce electric current is called its electromotive force or emf, mmf is taken as the work required to move a unit magnet pole from any point through any path which links the electric circuit back the same point in the presence of the magnetic force produced by the electric current in the circuit. \\(\\textbf{Magnetomotive Force}\\) is the scalar line integral of the magnetic field strength along a closed path."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Magnetomotive Force}) ((mmf)) is the ability of an electric circuit to produce magnetic flux. Just as the ability of a battery to produce electric current is called its electromotive force or emf, mmf is taken as the work required to move a unit magnet pole from any point through any path which links the electric circuit back the same point in the presence of the magnetic force produced by the electric current in the circuit. (textbf{Magnetomotive Force}) is the scalar line integral of the magnetic field strength along a closed path."^^xsd:string ;
 	skos:prefLabel "magnetomotive force"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_current ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5444,7 +5439,7 @@ gistd:_Aspect_mass
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Mass"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Mass> ;
-	skos:definition "from QUDT: In physics, mass, more specifically inertial mass, can be defined as a quantitative measure of an object's resistance to acceleration. The SI unit of mass is the kilogram (\\(kg\\))"^^xsd:string ;
+	skos:definition "from QUDT: In physics, mass, more specifically inertial mass, can be defined as a quantitative measure of an object's resistance to acceleration. The SI unit of mass is the kilogram ((kg))"^^xsd:string ;
 	skos:prefLabel "mass"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass ;
 	gist:isCategorizedBy gistd:_Discipline_propulsion ;
@@ -5509,7 +5504,7 @@ gistd:_Aspect_mass_concentration_of_water_to_dry_matter
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassRatioOfWaterToDryMatter> ;
-	skos:definition 'from QUDT: "Mass Ratio of Water to Dry Matter} is one of a number of \\textit{Concentration Ratio" quantities defined by ISO 8000.'^^xsd:string ;
+	skos:definition 'from QUDT: "Mass Ratio of Water to Dry Matter} is one of a number of {Concentration Ratio" quantities defined by ISO 8000.'^^xsd:string ;
 	skos:prefLabel "mass concentration of water to dry matter"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio_of_masses ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -5519,7 +5514,7 @@ gistd:_Aspect_mass_concentration_of_water_vapour
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassConcentrationOfWaterVapour> ;
-	skos:definition 'from QUDT: "Mass Concentration of Water} is one of a number of \\textit{Concentration" quantities defined by ISO 8000.'^^xsd:string ;
+	skos:definition 'from QUDT: "Mass Concentration of Water} is one of a number of {Concentration" quantities defined by ISO 8000.'^^xsd:string ;
 	skos:prefLabel "mass concentration of water vapour"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_density ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -5597,7 +5592,7 @@ gistd:_Aspect_mass_flow_rate
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassFlowRate> ;
-	skos:definition 'from QUDT: "Mass Flow Rate" is a measure of Mass flux. The common symbol is \\(\\dot{m}\\) (pronounced "m-dot"), although sometimes \\(\\mu\\) is used. The SI units are \\(kg s-1\\).'^^xsd:string ;
+	skos:definition 'from QUDT: Mass Flow Rate is a measure of Mass flux. The common symbol is (dot{m}) (pronounced "m-dot"), although sometimes (mu) is used. The SI units are (kg s-1).'^^xsd:string ;
 	skos:prefLabel "mass flow rate"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_per_time ;
 	gist:isCategorizedBy
@@ -5623,7 +5618,7 @@ gistd:_Aspect_mass_fraction_of_dry_matter
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassFractionOfDryMatter> ;
-	skos:definition 'from QUDT: "Mass Fraction of Dry Matter} is one of a number of \\textit{Concentration" quantities defined by ISO 8000.'^^xsd:string ;
+	skos:definition 'from QUDT: "Mass Fraction of Dry Matter} is one of a number of {Concentration" quantities defined by ISO 8000.'^^xsd:string ;
 	skos:prefLabel "mass fraction of dry matter"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio_of_masses ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -5633,7 +5628,7 @@ gistd:_Aspect_mass_fraction_of_water
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassFractionOfWater> ;
-	skos:definition 'from QUDT: "Mass Fraction of Water} is one of a number of \\textit{Concentration" quantities defined by ISO 8000.'^^xsd:string ;
+	skos:definition 'from QUDT: "Mass Fraction of Water} is one of a number of {Concentration" quantities defined by ISO 8000.'^^xsd:string ;
 	skos:prefLabel "mass fraction of water"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio_of_masses ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -5667,7 +5662,7 @@ gistd:_Aspect_mass_number
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassNumber> ;
-	skos:definition 'from QUDT: The "Mass Number" (A), also called atomic mass number or nucleon number, is the total number of protons and neutrons (together known as nucleons) in an atomic nucleus. Nuclides with the same value of \\(A\\) are called isobars.'^^xsd:string ;
+	skos:definition 'from QUDT: The "Mass Number" (A), also called atomic mass number or nucleon number, is the total number of protons and neutrons (together known as nucleons) in an atomic nucleus. Nuclides with the same value of (A) are called isobars.'^^xsd:string ;
 	skos:prefLabel "mass number"^^xsd:string ;
 	gist:hasUnitGroup
 		gistd:_UnitGroup_number ,
@@ -5700,7 +5695,7 @@ gistd:_Aspect_mass_per_area
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Area_density"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassPerArea> ;
-	skos:definition "from QUDT: The area density (also known as areal density, surface density, or superficial density) of a two-dimensional object is calculated as the mass per unit area. The SI derived unit is: kilogram per square metre (\\(kg \\cdot m^{-2}\\))."^^xsd:string ;
+	skos:definition "from QUDT: The area density (also known as areal density, surface density, or superficial density) of a two-dimensional object is calculated as the mass per unit area. The SI derived unit is: kilogram per square metre ((kg m^{-2}))."^^xsd:string ;
 	skos:prefLabel "mass per area"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_per_area ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -5710,7 +5705,7 @@ gistd:_Aspect_mass_per_area_time
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Mass_flux"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassPerAreaTime> ;
-	skos:definition "from QUDT: In Physics and Engineering, mass flux is the rate of mass flow per unit area. The common symbols are \\(j\\), \\(J\\), \\(\\phi\\), or \\(\\Phi\\) (Greek lower or capital Phi), sometimes with subscript \\(m\\) to indicate mass is the flowing quantity. Its SI units are \\( kg s^{-1} m^{-2}\\)."^^xsd:string ;
+	skos:definition "from QUDT: In Physics and Engineering, mass flux is the rate of mass flow per unit area. The common symbols are (j), (J), (phi), or (Phi) (Greek lower or capital Phi), sometimes with subscript (m) to indicate mass is the flowing quantity. Its SI units are ( kg s^{-1} m^{-2})."^^xsd:string ;
 	skos:prefLabel "mass per area time"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_per_area_time ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -5720,7 +5715,7 @@ gistd:_Aspect_mass_per_distance
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Linear_density"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassPerLength> ;
-	skos:definition "from QUDT: Linear density, linear mass density or linear mass is a measure of mass per unit of length, and it is a characteristic of strings or other one-dimensional objects. The SI unit of linear density is the kilogram per metre (\\(kg/m\\))."^^xsd:string ;
+	skos:definition "from QUDT: Linear density, linear mass density or linear mass is a measure of mass per unit of length, and it is a characteristic of strings or other one-dimensional objects. The SI unit of linear density is the kilogram per metre ((kg/m))."^^xsd:string ;
 	skos:prefLabel "mass per length"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_per_distance ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -5734,7 +5729,7 @@ gistd:_Aspect_mass_per_electric_charge
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Mass-to-charge_ratio"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassPerElectricCharge> ;
-	skos:definition "from QUDT: The mass-to-charge ratio ratio (\\(m/Q\\)) is a physical quantity that is widely used in the electrodynamics of charged particles, for example, in electron optics and ion optics. The importance of the mass-to-charge ratio, according to classical electrodynamics, is that two particles with the same mass-to-charge ratio move in the same path in a vacuum when subjected to the same electric and magnetic fields. Its SI units are \\(kg/C\\), but it can also be measured in Thomson (\\(Th\\))."^^xsd:string ;
+	skos:definition "from QUDT: The mass-to-charge ratio ratio ((m/Q)) is a physical quantity that is widely used in the electrodynamics of charged particles, for example, in electron optics and ion optics. The importance of the mass-to-charge ratio, according to classical electrodynamics, is that two particles with the same mass-to-charge ratio move in the same path in a vacuum when subjected to the same electric and magnetic fields. Its SI units are (kg/C), but it can also be measured in Thomson ((Th))."^^xsd:string ;
 	skos:prefLabel "mass per electric charge"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass_per_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -5791,7 +5786,7 @@ gistd:_Aspect_massieu_function
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MassieuFunction> ;
-	skos:definition "from QUDT: The Massieu function, \\(\\Psi\\), is defined as: \\(\\Psi = \\Psi (X_1, \\dots , X_i, Y_{i+1}, \\dots , Y_r )\\), where for every system with degree of freedom \\(r\\) one may choose \\(r\\) variables, e.g. , to define a coordinate system, where \\(X\\) and \\(Y\\) are extensive and intensive variables, respectively, and where at least one extensive variable must be within this set in order to define the size of the system. The \\((r + 1)^{th}\\) variable,\\(\\Psi\\) , is then called the Massieu function."^^xsd:string ;
+	skos:definition "from QUDT: The Massieu function, (Psi), is defined as: (Psi = Psi (X_1, dots , X_i, Y_{i+1}, dots , Y_r )), where for every system with degree of freedom (r) one may choose (r) variables, e.g. , to define a coordinate system, where (X) and (Y) are extensive and intensive variables, respectively, and where at least one extensive variable must be within this set in order to define the size of the system. The ((r + 1)^{th}) variable,(Psi) , is then called the Massieu function."^^xsd:string ;
 	skos:prefLabel "massieu function"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_temperature ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -5885,7 +5880,7 @@ gistd:_Aspect_mean_lifetime
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MeanLifetime> ;
-	skos:definition 'from QUDT: The "Mean Lifetime" is the average length of time that an element remains in the set of discrete elements in a decaying quantity, \\(N(t)\\).'^^xsd:string ;
+	skos:definition 'from QUDT: The "Mean Lifetime" is the average length of time that an element remains in the set of discrete elements in a decaying quantity, (N(t)).'^^xsd:string ;
 	skos:prefLabel "mean lifetime"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_duration ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -6094,7 +6089,7 @@ gistd:_Aspect_modulus_of_impedance
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ModulusOfImpedance> ;
-	skos:definition 'from QUDT: "Modulus Of Impedance} is the absolute value of the quantity \\textit{impedance". Apparent impedance is defined more generally as the quotient of rms voltage and rms electric current; it is often denoted by \\(Z\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Modulus Of Impedance} is the absolute value of the quantity {impedance". Apparent impedance is defined more generally as the quotient of rms voltage and rms electric current; it is often denoted by (Z).'^^xsd:string ;
 	skos:prefLabel "modulus of impedance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_resistance ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -6211,7 +6206,7 @@ gistd:_Aspect_molar_energy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MolarEnergy> ;
-	skos:definition 'from QUDT: "Molar Energy" is the total energy contained by a thermodynamic system. The unit is \\(J/mol\\), also expressed as \\(joule/mole\\), or \\(joules per mole\\). This unit is commonly used in the SI unit system. The quantity has the dimension of \\(M \\cdot L^2 \\cdot T^{-2} \\cdot N^{-1}\\) where \\(M\\) is mass, \\(L\\) is length, \\(T\\) is time, and \\(N\\) is amount of substance.'^^xsd:string ;
+	skos:definition 'from QUDT: "Molar Energy" is the total energy contained by a thermodynamic system. The unit is (J/mol), also expressed as (joule/mole), or (joules per mole). This unit is commonly used in the SI unit system. The quantity has the dimension of (M L^2 T^{-2} N^{-1}) where (M) is mass, (L) is length, (T) is time, and (N) is amount of substance.'^^xsd:string ;
 	skos:prefLabel "molar energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_molar_energy ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -6263,7 +6258,7 @@ gistd:_Aspect_molar_mass
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MolarMass> ;
-	skos:definition "from QUDT: In chemistry, the molar mass M is defined as the mass of a given substance (chemical element or chemical compound) divided by its amount of substance. It is a physical property of a given substance. The base SI unit for molar mass is \\(kg/mol\\)."^^xsd:string ;
+	skos:definition "from QUDT: In chemistry, the molar mass M is defined as the mass of a given substance (chemical element or chemical compound) divided by its amount of substance. It is a physical property of a given substance. The base SI unit for molar mass is (kg/mol)."^^xsd:string ;
 	skos:prefLabel "molar mass"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_molar_mass ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -6307,7 +6302,7 @@ gistd:_Aspect_molar_volume
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MolarVolume> ;
-	skos:definition "from QUDT: The molar volume, symbol \\(V_m\\), is the volume occupied by one mole of a substance (chemical element or chemical compound) at a given temperature and pressure. It is equal to the molar mass (\\(M\\)) divided by the mass density (\\(\\rho\\)). It has the SI unit cubic metres per mole (\\(m^{1}/mol\\)). For ideal gases, the molar volume is given by the ideal gas equation: this is a good approximation for many common gases at standard temperature and pressure. For crystalline solids, the molar volume can be measured by X-ray crystallography."^^xsd:string ;
+	skos:definition "from QUDT: The molar volume, symbol (V_m), is the volume occupied by one mole of a substance (chemical element or chemical compound) at a given temperature and pressure. It is equal to the molar mass ((M)) divided by the mass density ((rho)). It has the SI unit cubic metres per mole ((m^{1}/mol)). For ideal gases, the molar volume is given by the ideal gas equation: this is a good approximation for many common gases at standard temperature and pressure. For crystalline solids, the molar volume can be measured by X-ray crystallography."^^xsd:string ;
 	skos:prefLabel "molar volume"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_molar_volume ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -6451,7 +6446,7 @@ gistd:_Aspect_mutual_inductance
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/MutualInductance> ;
-	skos:definition "from QUDT: \\(\\textit{Mutual Inductance}\\) is the non-diagonal term of the inductance matrix. For two loops, the symbol \\(M\\) is used for \\(L_{12}\\)."^^xsd:string ;
+	skos:definition "from QUDT: ({Mutual Inductance}) is the non-diagonal term of the inductance matrix. For two loops, the symbol (M) is used for (L_{12})."^^xsd:string ;
 	skos:prefLabel "mutual inductance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inductance ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -6510,7 +6505,7 @@ gistd:_Aspect_neutron_number
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/NeutronNumber> ;
-	skos:definition 'from QUDT: "Neutron Number", symbol \\(N\\), is the number of neutrons in a nuclide. Nuclides with the same value of \\(N\\) but different values of \\(Z\\) are called isotones. \\(N - Z\\) is called the neutron excess number.'^^xsd:string ;
+	skos:definition 'from QUDT: "Neutron Number", symbol (N), is the number of neutrons in a nuclide. Nuclides with the same value of (N) but different values of (Z) are called isotones. (N - Z) is called the neutron excess number.'^^xsd:string ;
 	skos:prefLabel "neutron number"^^xsd:string ;
 	gist:hasUnitGroup
 		gistd:_UnitGroup_number ,
@@ -6795,7 +6790,7 @@ gistd:_Aspect_orbital_angular_momentum_quantum_number
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/OrbitalAngularMomentumQuantumNumber> ;
-	skos:definition 'from QUDT: The "Principal Quantum Number" describes the electron shell, or energy level, of an atom. The value of \\(n\\) ranges from 1 to the shell containing the outermost electron of that atom.'^^xsd:string ;
+	skos:definition 'from QUDT: The "Principal Quantum Number" describes the electron shell, or energy level, of an atom. The value of (n) ranges from 1 to the shell containing the outermost electron of that atom.'^^xsd:string ;
 	skos:prefLabel "orbital angular momentum quantum number"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_quantum_number ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -6816,7 +6811,7 @@ gistd:_Aspect_order_of_reflection
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/OrderOfReflection> ;
-	skos:definition "from QUDT: \"Order of Reflection\" is \\(n\\) in the Bragg's Law equation."^^xsd:string ;
+	skos:definition "from QUDT: Order of Reflection is (n) in the Bragg's Law equation."^^xsd:string ;
 	skos:prefLabel "order of reflection"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_number ;
 	gist:isCategorizedBy gistd:_Discipline_solid_state_physics ;
@@ -7037,7 +7032,7 @@ gistd:_Aspect_permeability
 		<http://qudt.org/vocab/quantitykind/ElectromagneticPermeability> ,
 		<http://qudt.org/vocab/quantitykind/Permeability>
 		;
-	skos:definition 'from QUDT: "Permeability} is the degree of magnetization of a material that responds linearly to an applied magnetic field. In general permeability is a tensor-valued quantity. The definition given applies to an isotropic medium. For an anisotropic medium permeability is a second order tensor. In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself. In other words, it is the degree of magnetization that a material obtains in response to an applied magnetic field. Magnetic permeability is typically represented by the Greek letter \\(\\mu\\). The term was coined in September, 1885 by Oliver Heaviside. The reciprocal of magnetic permeability is \\textit{Magnetic Reluctivity".'^^xsd:string ;
+	skos:definition 'from QUDT: "Permeability} is the degree of magnetization of a material that responds linearly to an applied magnetic field. In general permeability is a tensor-valued quantity. The definition given applies to an isotropic medium. For an anisotropic medium permeability is a second order tensor. In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself. In other words, it is the degree of magnetization that a material obtains in response to an applied magnetic field. Magnetic permeability is typically represented by the Greek letter (mu). The term was coined in September, 1885 by Oliver Heaviside. The reciprocal of magnetic permeability is {Magnetic Reluctivity".'^^xsd:string ;
 	skos:prefLabel "permeability"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_permeability ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -7093,7 +7088,7 @@ gistd:_Aspect_phase_coefficient
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Attenuation_coefficient"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/PhaseCoefficient> ;
-	skos:definition "from QUDT: The phase coefficient is the amount of phase shift that occurs as the wave travels one meter. Increasing the loss of the material, via the manipulation of the material's conductivity, will decrease the wavelength (increase \\(\\beta\\)) and increase the attenuation coefficient (increase \\(\\alpha\\))."^^xsd:string ;
+	skos:definition "from QUDT: The phase coefficient is the amount of phase shift that occurs as the wave travels one meter. Increasing the loss of the material, via the manipulation of the material's conductivity, will decrease the wavelength (increase (beta)) and increase the attenuation coefficient (increase (alpha))."^^xsd:string ;
 	skos:prefLabel "phase coefficient"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_inverse_distance ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -7108,7 +7103,7 @@ gistd:_Aspect_phase_difference
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/PhaseDifference> ;
-	skos:definition 'from QUDT: "Phase Difference} is the difference, expressed in electrical degrees or time, between two waves having the same frequency and referenced to the same point in time. Two oscillators that have the same frequency and different phases have a phase difference, and the oscillators are said to be out of phase with each other. The amount by which such oscillators are out of step with each other can be expressed in degrees from \\SI{0}{\\degree} to \\SI{360}{\\degree}, or in radians from 0 to \\num{2\\pi". If the phase difference is 180 degrees (\\(\\pi\\) radians), then the two oscillators are said to be in antiphase.'^^xsd:string ;
+	skos:definition 'from QUDT: "Phase Difference} is the difference, expressed in electrical degrees or time, between two waves having the same frequency and referenced to the same point in time. Two oscillators that have the same frequency and different phases have a phase difference, and the oscillators are said to be out of phase with each other. The amount by which such oscillators are out of step with each other can be expressed in degrees from SI{0}{degree} to SI{360}{degree}, or in radians from 0 to num{2pi". If the phase difference is 180 degrees ((pi) radians), then the two oscillators are said to be in antiphase.'^^xsd:string ;
 	skos:prefLabel "phase difference"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angle ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -7201,7 +7196,7 @@ gistd:_Aspect_planck_function
 		"https://www.star.nesdis.noaa.gov/smcd/spb/calibration/planck.html"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/PlanckFunction> ;
-	skos:definition 'from QUDT: The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect "Black Body". The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object. The precise formula for the Planck Function depends on whether the radiance is determined on a \\(\\textit{per unit wavelength}\\) or a \\(\\textit{per unit frequency}\\). In the ISO System of Quantities, \\(\\textit{Planck Function}\\) is defined by the formula: \\(Y = -G/T\\), where \\(G\\) is Gibbs Energy and \\(T\\) is thermodynamic temperature.'^^xsd:string ;
+	skos:definition 'from QUDT: The ({Planck function}) is used to compute the radiance emitted from objects that radiate like a perfect "Black Body". The inverse of the ({Planck Function}) is used to find the ({Brightness Temperature}) of an object. The precise formula for the Planck Function depends on whether the radiance is determined on a ({per unit wavelength}) or a ({per unit frequency}). In the ISO System of Quantities, ({Planck Function}) is defined by the formula: (Y = -G/T), where (G) is Gibbs Energy and (T) is thermodynamic temperature.'^^xsd:string ;
 	skos:prefLabel "planck function"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_planck_function ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -7213,7 +7208,7 @@ gistd:_Aspect_plane_angle
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/PlaneAngle> ;
 	skos:definition
 		"from QUDT: An angle formed by two straight lines (in the same plane) angle - the space between two lines or planes that intersect; the inclination of one line to another; measured in degrees or radians"^^xsd:string ,
-		"from QUDT: The inclination to each other of two intersecting lines, measured by the arc of a circle intercepted between the two lines forming the angle, the center of the circle being the point of intersection. An acute angle is less than \\(90^\\circ\\), a right angle \\(90^\\circ\\); an obtuse angle, more than \\(90^\\circ\\) but less than \\(180^\\circ\\); a straight angle, \\(180^\\circ\\); a reflex angle, more than \\(180^\\circ\\) but less than \\(360^\\circ\\); a perigon, \\(360^\\circ\\). Any angle not a multiple of \\(90^\\circ\\) is an oblique angle. If the sum of two angles is \\(90^\\circ\\), they are complementary angles; if \\(180^\\circ\\), supplementary angles; if \\(360^\\circ\\), explementary angles."^^xsd:string
+		"from QUDT: The inclination to each other of two intersecting lines, measured by the arc of a circle intercepted between the two lines forming the angle, the center of the circle being the point of intersection. An acute angle is less than (90^circ), a right angle (90^circ); an obtuse angle, more than (90^circ) but less than (180^circ); a straight angle, (180^circ); a reflex angle, more than (180^circ) but less than (360^circ); a perigon, (360^circ). Any angle not a multiple of (90^circ) is an oblique angle. If the sum of two angles is (90^circ), they are complementary angles; if (180^circ), supplementary angles; if (360^circ), explementary angles."^^xsd:string
 		;
 	skos:prefLabel "plane angle"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angle ;
@@ -7246,7 +7241,7 @@ gistd:_Aspect_polar_moment_of_inertia
 gistd:_Aspect_polarizability
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Polarizability> ;
-	skos:definition 'from QUDT: "Polarizability" is the relative tendency of a charge distribution, like the electron cloud of an atom or molecule, to be distorted from its normal shape by an external electric field, which may be caused by the presence of a nearby ion or dipole. The electronic polarizability \\(\\alpha\\) is defined as the ratio of the induced dipole moment of an atom to the electric field that produces this dipole moment. Polarizability is often a scalar valued quantity, however in the general case it is tensor-valued.'^^xsd:string ;
+	skos:definition 'from QUDT: "Polarizability" is the relative tendency of a charge distribution, like the electron cloud of an atom or molecule, to be distorted from its normal shape by an external electric field, which may be caused by the presence of a nearby ion or dipole. The electronic polarizability (alpha) is defined as the ratio of the induced dipole moment of an atom to the electric field that produces this dipole moment. Polarizability is often a scalar valued quantity, however in the general case it is tensor-valued.'^^xsd:string ;
 	skos:prefLabel "polarizability"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_polarizability ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -7317,7 +7312,7 @@ gistd:_Aspect_power
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Power> ;
-	skos:definition "from QUDT: Power is the rate at which work is performed or energy is transmitted, or the amount of energy required or expended for a given unit of time. As a rate of change of work done or the energy of a subsystem, power is: \\(P = W/t\\), where \\(P\\) is power, \\(W\\) is work and {t} is time."^^xsd:string ;
+	skos:definition "from QUDT: Power is the rate at which work is performed or energy is transmitted, or the amount of energy required or expended for a given unit of time. As a rate of change of work done or the energy of a subsystem, power is: (P = W/t), where (P) is power, (W) is work and {t} is time."^^xsd:string ;
 	skos:prefLabel "power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_power ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -7346,7 +7341,7 @@ gistd:_Aspect_power_factor
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/PowerFactor> ;
-	skos:definition 'from QUDT: "Power Factor", under periodic conditions, is the ratio of the absolute value of the active power \\(P\\) to the apparent power \\(S\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Power Factor", under periodic conditions, is the ratio of the absolute value of the active power (P) to the apparent power (S).'^^xsd:string ;
 	skos:prefLabel "power factor"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -7587,7 +7582,7 @@ gistd:_Aspect_ratio_of_specific_heat_capacities
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/RatioOfSpecificHeatCapacities> ;
-	skos:definition 'from QUDT: The specific heat ratio of a gas is the ratio of the specific heat at constant pressure, \\(c_p\\), to the specific heat at constant volume, \\(c_V\\). It is sometimes referred to as the "adiabatic index} or the \\textit{heat capacity ratio} or the \\textit{isentropic expansion factor} or the \\textit{adiabatic exponent} or the \\textit{isentropic exponent".'^^xsd:string ;
+	skos:definition 'from QUDT: The specific heat ratio of a gas is the ratio of the specific heat at constant pressure, (c_p), to the specific heat at constant volume, (c_V). It is sometimes referred to as the "adiabatic index} or the {heat capacity ratio} or the {isentropic expansion factor} or the {adiabatic exponent} or the {isentropic exponent".'^^xsd:string ;
 	skos:prefLabel "ratio of specific heat capacities"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -7643,7 +7638,7 @@ gistd:_Aspect_reactive_power
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ReactivePower> ;
-	skos:definition 'from QUDT: "Reactive Power}, for a linear two-terminal element or two-terminal circuit, under sinusoidal conditions, is the quantity equal to the product of the apparent power \\(S\\) and the sine of the displacement angle \\(\\psi\\). The absolute value of the reactive power is equal to the non-active power. The ISO (and SI) unit for reactive power is the voltampere. The special name \\(\\textit{var}\\) and symbol \\(\\textit{var}\\) are given in IEC 60027 1.'^^xsd:string ;
+	skos:definition 'from QUDT: "Reactive Power}, for a linear two-terminal element or two-terminal circuit, under sinusoidal conditions, is the quantity equal to the product of the apparent power (S) and the sine of the displacement angle (psi). The absolute value of the reactive power is equal to the non-active power. The ISO (and SI) unit for reactive power is the voltampere. The special name ({var}) and symbol ({var}) are given in IEC 60027 1.'^^xsd:string ;
 	skos:prefLabel "reactive power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_electric_power ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -7774,7 +7769,7 @@ gistd:_Aspect_relative_humidity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/RelativeHumidity> ;
-	skos:definition "from QUDT: \\(\\textit{Relative Humidity}\\) is the ratio of the partial pressure of water vapor in an air-water mixture to the saturated vapor pressure of water at a prescribed temperature. The relative humidity of air depends not only on temperature but also on the pressure of the system of interest. \\(\\textit{Relative Humidity}\\) is also referred to as \\(\\textit{Relative Partial Pressure}\\). Relative partial pressure is often referred to as \\(RH\\) and expressed in percent."^^xsd:string ;
+	skos:definition "from QUDT: ({Relative Humidity}) is the ratio of the partial pressure of water vapor in an air-water mixture to the saturated vapor pressure of water at a prescribed temperature. The relative humidity of air depends not only on temperature but also on the pressure of the system of interest. ({Relative Humidity}) is also referred to as ({Relative Partial Pressure}). Relative partial pressure is often referred to as (RH) and expressed in percent."^^xsd:string ;
 	skos:prefLabel "relative humidity"^^xsd:string ;
 	gist:hasUnitGroup
 		gistd:_UnitGroup_percentage ,
@@ -8034,7 +8029,7 @@ gistd:_Aspect_rest_mass
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/RestMass> ;
-	skos:definition "from QUDT: The \\(\\textit{Rest Mass}\\), the invariant mass, intrinsic mass, proper mass, or (in the case of bound systems or objects observed in their center of momentum frame) simply mass, is a characteristic of the total energy and momentum of an object or a system of objects that is the same in all frames of reference related by Lorentz transformations. The mass of a particle type X (electron, proton or neutron) when that particle is at rest. For an electron: \\(m_e = 9,109 382 15(45) 10^{-31} kg\\), for a proton: \\(m_p = 1,672 621 637(83) 10^{-27} kg\\), for a neutron: \\(m_n = 1,674 927 211(84) 10^{-27} kg\\). Rest mass is often denoted \\(m_0\\)."^^xsd:string ;
+	skos:definition "from QUDT: The ({Rest Mass}), the invariant mass, intrinsic mass, proper mass, or (in the case of bound systems or objects observed in their center of momentum frame) simply mass, is a characteristic of the total energy and momentum of an object or a system of objects that is the same in all frames of reference related by Lorentz transformations. The mass of a particle type X (electron, proton or neutron) when that particle is at rest. For an electron: (m_e = 9,109 382 15(45) 10^{-31} kg), for a proton: (m_p = 1,672 621 637(83) 10^{-27} kg), for a neutron: (m_n = 1,674 927 211(84) 10^{-27} kg). Rest mass is often denoted (m_0)."^^xsd:string ;
 	skos:prefLabel "rest mass"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_mass ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -8242,7 +8237,7 @@ gistd:_Aspect_shear_modulus
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ShearModulus> ;
-	skos:definition "from QUDT: The Shear Modulus or modulus of rigidity, denoted by \\(G\\), or sometimes \\(S\\) or \\(\\mu\\), is defined as the ratio of shear stress to the shear strain."^^xsd:string ;
+	skos:definition "from QUDT: The Shear Modulus or modulus of rigidity, denoted by (G), or sometimes (S) or (mu), is defined as the ratio of shear stress to the shear strain."^^xsd:string ;
 	skos:prefLabel "shear modulus"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_shear_modulus ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -8381,7 +8376,7 @@ gistd:_Aspect_sound_energy_density
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Sound_energy_density"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundEnergyDensity> ;
-	skos:definition "from QUDT: Sound energy density is the time-averaged sound energy in a given volume divided by that volume. The sound energy density or sound density (symbol \\(E\\) or \\(w\\)) is an adequate measure to describe the sound field at a given point as a sound energy value."^^xsd:string ;
+	skos:definition "from QUDT: Sound energy density is the time-averaged sound energy in a given volume divided by that volume. The sound energy density or sound density (symbol (E) or (w)) is an adequate measure to describe the sound field at a given point as a sound energy value."^^xsd:string ;
 	skos:prefLabel "sound energy density"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_density ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8400,7 +8395,7 @@ gistd:_Aspect_sound_exposure
 gistd:_Aspect_sound_exposure_level
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundExposureLevel> ;
-	skos:definition "from QUDT: Sound Exposure Level abbreviated as \\(SEL\\) and \\(LAE\\), is the total noise energy produced from a single noise event, expressed as a logarithmic ratio from a reference level."^^xsd:string ;
+	skos:definition "from QUDT: Sound Exposure Level abbreviated as (SEL) and (LAE), is the total noise energy produced from a single noise event, expressed as a logarithmic ratio from a reference level."^^xsd:string ;
 	skos:prefLabel "sound exposure level"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_sound_power_level ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8410,7 +8405,7 @@ gistd:_Aspect_sound_intensity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Sound_intensity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundIntensity> ;
-	skos:definition "from QUDT: Sound intensity or acoustic intensity (\\(I\\)) is defined as the sound power \\(P_a\\) per unit area \\(A\\). The usual context is the noise measurement of sound intensity in the air at a listener's location as a sound energy quantity."^^xsd:string ;
+	skos:definition "from QUDT: Sound intensity or acoustic intensity ((I)) is defined as the sound power (P_a) per unit area (A). The usual context is the noise measurement of sound intensity in the air at a listener's location as a sound energy quantity."^^xsd:string ;
 	skos:prefLabel "sound intensity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_power_per_area ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8420,7 +8415,7 @@ gistd:_Aspect_sound_particle_acceleration
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Particle_acceleration"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundParticleAcceleration> ;
-	skos:definition "from QUDT: In a compressible sound transmission medium - mainly air - air particles get an accelerated motion: the particle acceleration or sound acceleration with the symbol a in \\(m/s2\\). In acoustics or physics, acceleration (symbol: \\(a\\)) is defined as the rate of change (or time derivative) of velocity."^^xsd:string ;
+	skos:definition "from QUDT: In a compressible sound transmission medium - mainly air - air particles get an accelerated motion: the particle acceleration or sound acceleration with the symbol a in (m/s2). In acoustics or physics, acceleration (symbol: (a)) is defined as the rate of change (or time derivative) of velocity."^^xsd:string ;
 	skos:prefLabel "sound particle acceleration"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_acceleration ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8450,7 +8445,7 @@ gistd:_Aspect_sound_power
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Sound_power"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundPower> ;
-	skos:definition "from QUDT: Sound power or acoustic power \\(P_a\\) is a measure of sonic energy \\(E\\) per time \\(t\\) unit. It is measured in watts and can be computed as sound intensity (\\(I\\)) times area (\\(A\\))."^^xsd:string ;
+	skos:definition "from QUDT: Sound power or acoustic power (P_a) is a measure of sonic energy (E) per time (t) unit. It is measured in watts and can be computed as sound intensity ((I)) times area ((A))."^^xsd:string ;
 	skos:prefLabel "sound power"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_sound_power ;
 	gist:isCategorizedBy
@@ -8463,7 +8458,7 @@ gistd:_Aspect_sound_power_level
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Sound_power#Sound_power_level"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundPowerLevel> ;
-	skos:definition "from QUDT: Sound Power Level abbreviated as \\(SWL\\) expresses sound power more practically as a relation to the threshold of hearing - 1 picoW - in a logarithmic scale."^^xsd:string ;
+	skos:definition "from QUDT: Sound Power Level abbreviated as (SWL) expresses sound power more practically as a relation to the threshold of hearing - 1 picoW - in a logarithmic scale."^^xsd:string ;
 	skos:prefLabel "sound power level"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_sound_power_level ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8487,7 +8482,7 @@ gistd:_Aspect_sound_pressure_level
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Sound_pressure#Sound_pressure_level"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundPressureLevel> ;
-	skos:definition "from QUDT: Sound pressure level (\\(SPL\\)) or sound level is a logarithmic measure of the effective sound pressure of a sound relative to a reference value. It is measured in decibels (dB) above a standard reference level."^^xsd:string ;
+	skos:definition "from QUDT: Sound pressure level ((SPL)) or sound level is a logarithmic measure of the effective sound pressure of a sound relative to a reference value. It is measured in decibels (dB) above a standard reference level."^^xsd:string ;
 	skos:prefLabel "sound pressure level"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_sound_power_level ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8507,7 +8502,7 @@ gistd:_Aspect_sound_volume_velocity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Acoustic_impedance"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SoundVolumeVelocity> ;
-	skos:definition "from QUDT: Sound Volume Velocity is the product of particle velocity \\(v\\) and the surface area \\(S\\) through which an acoustic wave of frequency \\(f\\) propagates. Also, the surface integral of the normal component of the sound particle velocity over the cross section (through which the sound propagates). It is used to calculate acoustic impedance."^^xsd:string ;
+	skos:definition "from QUDT: Sound Volume Velocity is the product of particle velocity (v) and the surface area (S) through which an acoustic wave of frequency (f) propagates. Also, the surface integral of the normal component of the sound particle velocity over the cross section (through which the sound propagates). It is used to calculate acoustic impedance."^^xsd:string ;
 	skos:prefLabel "sound volume velocity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_sound_volume_velocity ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -8517,7 +8512,7 @@ gistd:_Aspect_source_voltage
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SourceVoltage> ;
-	skos:definition 'from QUDT: "Source Voltage}, also referred to as \\textit{Source Tension" is the voltage between the two terminals of a voltage source when there is no electric current through the source. The name "electromotive force} with the abbreviation \\textit{EMF" and the symbol \\(E\\) is deprecated.'^^xsd:string ;
+	skos:definition 'from QUDT: "Source Voltage}, also referred to as {Source Tension" is the voltage between the two terminals of a voltage source when there is no electric current through the source. The name "electromotive force} with the abbreviation {EMF" and the symbol (E) is deprecated.'^^xsd:string ;
 	skos:prefLabel "source voltage"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -8574,7 +8569,7 @@ gistd:_Aspect_specific_energy
 		"https://en.wikipedia.org/wiki/Specific_energy"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificEnergy> ;
-	skos:definition "from QUDT: \\(\\textbf{Specific Energy}\\) is defined as the energy per unit mass. Common metric units are \\(J/kg\\). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the \\(\\textbf{gray}\\) and \\(\\textbf{sievert}\\), which are measures for the absorption of radiation. The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property, which is symbolized by a capital letter. For example, the extensive thermodynamic property enthalpy is symbolized by \\(H\\); specific enthalpy is symbolized by \\(h\\)."^^xsd:string ;
+	skos:definition "from QUDT: (textbf{Specific Energy}) is defined as the energy per unit mass. Common metric units are (J/kg). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the (textbf{gray}) and (textbf{sievert}), which are measures for the absorption of radiation. The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property, which is symbolized by a capital letter. For example, the extensive thermodynamic property enthalpy is symbolized by (H); specific enthalpy is symbolized by (h)."^^xsd:string ;
 	skos:prefLabel "specific energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_energy ;
 	gist:isCategorizedBy
@@ -8603,7 +8598,7 @@ gistd:_Aspect_specific_enthalpy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificEnthalpy> ;
-	skos:definition "from QUDT: \\(\\textit{Specific Enthalpy}\\) is enthalpy per mass of substance involved. Specific enthalpy is denoted by a lower case h, with dimension of energy per mass (SI unit: joule/kg). In thermodynamics, \\(\\textit{enthalpy}\\) is the sum of the internal energy U and the product of pressure p and volume V of a system: \\(H = U + pV\\). The internal energy U and the work term pV have dimension of energy, in SI units this is joule; the extensive (linear in size) quantity H has the same dimension."^^xsd:string ;
+	skos:definition "from QUDT: ({Specific Enthalpy}) is enthalpy per mass of substance involved. Specific enthalpy is denoted by a lower case h, with dimension of energy per mass (SI unit: joule/kg). In thermodynamics, ({enthalpy}) is the sum of the internal energy U and the product of pressure p and volume V of a system: (H = U + pV). The internal energy U and the work term pV have dimension of energy, in SI units this is joule; the extensive (linear in size) quantity H has the same dimension."^^xsd:string ;
 	skos:prefLabel "specific enthalpy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_enthalpy ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -8626,7 +8621,7 @@ gistd:_Aspect_specific_gibbs_energy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificGibbsEnergy> ;
-	skos:definition 'from QUDT: Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is "Specific Gibbs Energy}, which is \\textit{Gibbs Energy} per mass of substance involved. \\textit{Specific Gibbs Energy" is denoted by a lower case g, with dimension of energy per mass (SI unit: joule/kg).'^^xsd:string ;
+	skos:definition 'from QUDT: Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is "Specific Gibbs Energy}, which is {Gibbs Energy} per mass of substance involved. {Specific Gibbs Energy" is denoted by a lower case g, with dimension of energy per mass (SI unit: joule/kg).'^^xsd:string ;
 	skos:prefLabel "specific gibbs energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_energy ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -8636,7 +8631,7 @@ gistd:_Aspect_specific_heat_capacity
 	a gist:Aspect ;
 	rdfs:seeAlso "http://www.taftan.com/thermodynamics/CP.HTM"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificHeatCapacity> ;
-	skos:definition 'from QUDT: "Specific Heat Capacity} of a solid or liquid is defined as the heat required to raise unit mass of substance by one degree of temperature. This is \\textit{Heat Capacity} divied by \\textit{Mass". Note that there are corresponding molar quantities.'^^xsd:string ;
+	skos:definition 'from QUDT: "Specific Heat Capacity} of a solid or liquid is defined as the heat required to raise unit mass of substance by one degree of temperature. This is {Heat Capacity} divied by {Mass". Note that there are corresponding molar quantities.'^^xsd:string ;
 	skos:prefLabel "specific heat capacity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_heat_capacity ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -8691,7 +8686,7 @@ gistd:_Aspect_specific_heat_volume
 gistd:_Aspect_specific_heats_ratio
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificHeatsRatio> ;
-	skos:definition "from QUDT: The ratio of specific heats, for the exhaust gases adiabatic gas constant, is the relative amount of compression/expansion energy that goes into temperature \\(T\\) versus pressure \\(P\\) can be characterized by the heat capacity ratio: \\(\\gamma\\frac{C_P}{C_V}\\), where \\(C_P\\) is the specific heat (also called heat capacity) at constant pressure, while \\(C_V\\) is the specific heat at constant volume. "^^xsd:string ;
+	skos:definition "from QUDT: The ratio of specific heats, for the exhaust gases adiabatic gas constant, is the relative amount of compression/expansion energy that goes into temperature (T) versus pressure (P) can be characterized by the heat capacity ratio: C_P/C_V, where (C_P) is the specific heat (also called heat capacity) at constant pressure, while (C_V) is the specific heat at constant volume. "^^xsd:string ;
 	skos:prefLabel "specific heats ratio"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_propulsion ;
@@ -8704,7 +8699,7 @@ gistd:_Aspect_specific_helmholtz_energy
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificHelmholtzEnergy> ;
-	skos:definition "from QUDT: Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is \\(\\textit{Specific Helmholtz Energy}\\), which is \\(\\textit{Helmholz Energy}\\) per mass of substance involved.\\( \\textit{Specific Helmholz Energy}\\) is denoted by a lower case u, with dimension of energy per mass (SI unit: joule/kg)."^^xsd:string ;
+	skos:definition "from QUDT: Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is ({Specific Helmholtz Energy}), which is ({Helmholz Energy}) per mass of substance involved.( {Specific Helmholz Energy}) is denoted by a lower case u, with dimension of energy per mass (SI unit: joule/kg)."^^xsd:string ;
 	skos:prefLabel "specific helmholtz energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_energy ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -8714,7 +8709,7 @@ gistd:_Aspect_specific_impulse
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/specific-impulse"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificImpulse> ;
-	skos:definition "from QUDT: The impulse produced by a rocket divided by the mass \\(mp\\) of propellant consumed. Specific impulse \\({I_{sp}}\\) is a widely used measure of performance for chemical, nuclear, and electric rockets. It is usually given in seconds for both U.S. Customary and International System (SI) units. The impulse produced by a rocket is the thrust force \\(F\\) times its duration \\(t\\) in seconds. \\(I_{sp}\\) is the thrust per unit mass flowrate, but with \\(g_o\\), is the thrust per weight flowrate. The specific impulse is given by the equation: \\(I_{sp} = \\frac{F}{\\dot{m}g_o}\\)."^^xsd:string ;
+	skos:definition "from QUDT: The impulse produced by a rocket divided by the mass (mp) of propellant consumed. Specific impulse ({I_{sp}}) is a widely used measure of performance for chemical, nuclear, and electric rockets. It is usually given in seconds for both U.S. Customary and International System (SI) units. The impulse produced by a rocket is the thrust force (F) times its duration (t) in seconds. (I_{sp}) is the thrust per unit mass flowrate, but with (g_o), is the thrust per weight flowrate. The specific impulse is given by the equation: (I_sp = F/m g_o)."^^xsd:string ;
 	skos:prefLabel "specific impulse"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_impulse ;
 	gist:isCategorizedBy gistd:_Discipline_propulsion ;
@@ -8772,7 +8767,7 @@ gistd:_Aspect_specific_volume
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpecificVolume> ;
-	skos:definition 'from QUDT: "Specific Volume" (\\(\\nu\\)) is the volume occupied by a unit of mass of a material. It is equal to the inverse of density.'^^xsd:string ;
+	skos:definition 'from QUDT: "Specific Volume" ((nu)) is the volume occupied by a unit of mass of a material. It is equal to the inverse of density.'^^xsd:string ;
 	skos:prefLabel "specific volume"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_specific_volume ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -8785,7 +8780,7 @@ gistd:_Aspect_spectral_angular_cross_section
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpectralAngularCrossSection> ;
-	skos:definition 'from QUDT: "Spectral Angular Cross-section" is the cross section for ejecting or scattering a particle into an elementary cone with energy \\(E\\) in an energy interval, divided by the solid angle \\(d\\Omega\\) of that cone and the range \\(dE\\) of that interval.'^^xsd:string ;
+	skos:definition 'from QUDT: "Spectral Angular Cross-section" is the cross section for ejecting or scattering a particle into an elementary cone with energy (E) in an energy interval, divided by the solid angle (dOmega) of that cone and the range (dE) of that interval.'^^xsd:string ;
 	skos:prefLabel "spectral angular cross section"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_compressibility ;
 	gist:isCategorizedBy
@@ -8802,7 +8797,7 @@ gistd:_Aspect_spectral_cross_section
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpectralCrossSection> ;
-	skos:definition 'from QUDT: "Spectral Cross-section" is the cross section for a process in which the energy of the ejected or scattered particle is in an interval of energy, divided by the range \\(dE\\) of this interval.'^^xsd:string ;
+	skos:definition 'from QUDT: "Spectral Cross-section" is the cross section for a process in which the energy of the ejected or scattered particle is in an interval of energy, divided by the range (dE) of this interval.'^^xsd:string ;
 	skos:prefLabel "spectral cross section"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_linear_compressibility ;
 	gist:isCategorizedBy
@@ -8853,7 +8848,7 @@ gistd:_Aspect_speed_of_light
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/SpeedOfLight> ;
-	skos:definition "from QUDT: The quantity kind \\(\\textbf{Speed of Light}\\) is the speed of electomagnetic waves in a given medium."^^xsd:string ;
+	skos:definition "from QUDT: The quantity kind (textbf{Speed of Light}) is the speed of electomagnetic waves in a given medium."^^xsd:string ;
 	skos:prefLabel "speed of light"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_speed_of_light ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -8925,7 +8920,7 @@ gistd:_Aspect_standard_absolute_activity
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/StandardAbsoluteActivity> ;
-	skos:definition 'from QUDT: The "Standard Absolute Activity" is proportional to the absoulte activity of the pure substance \\(B\\) at the same temperature and pressure multiplied by the standard pressure.'^^xsd:string ;
+	skos:definition 'from QUDT: The "Standard Absolute Activity" is proportional to the absoulte activity of the pure substance (B) at the same temperature and pressure multiplied by the standard pressure.'^^xsd:string ;
 	skos:prefLabel "standard absolute activity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_number ;
 	gist:isCategorizedBy gistd:_Discipline_chemistry ;
@@ -8948,7 +8943,7 @@ gistd:_Aspect_standard_gravitational_parameter
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Standard_gravitational_parameter"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/StandardGravitationalParameter> ;
-	skos:definition "from QUDT: In celestial mechanics the standard gravitational parameter of a celestial body is the product of the gravitational constant G and the mass M of the body. Expressed as \\(\\mu = G \\cdot M\\). The SI units of the standard gravitational parameter are \\(m^{3}s^{-2}\\)."^^xsd:string ;
+	skos:definition "from QUDT: In celestial mechanics the standard gravitational parameter of a celestial body is the product of the gravitational constant G and the mass M of the body. Expressed as (mu = G M). The SI units of the standard gravitational parameter are (m^{3}s^{-2})."^^xsd:string ;
 	skos:prefLabel "standard gravitational parameter"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_standard_gravitational_parameter ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -9002,7 +8997,7 @@ gistd:_Aspect_static_pressure
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Static_pressure"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/StaticPressure> ;
-	skos:definition 'from QUDT: "Static Pressure" is the pressure at a nominated point in a fluid. Every point in a steadily flowing fluid, regardless of the fluid speed at that point, has its own static pressure \\(P\\), dynamic pressure \\(q\\), and total pressure \\(P_0\\). The total pressure is the sum of the dynamic and static pressures, that is \\(P_0 = P + q\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Static Pressure" is the pressure at a nominated point in a fluid. Every point in a steadily flowing fluid, regardless of the fluid speed at that point, has its own static pressure (P), dynamic pressure (q), and total pressure (P_0). The total pressure is the sum of the dynamic and static pressures, that is (P_0 = P + q).'^^xsd:string ;
 	skos:prefLabel "static pressure"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_fluid_pressure ;
 	gist:isCategorizedBy
@@ -9070,7 +9065,7 @@ gistd:_Aspect_stress
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Stress_(mechanics)"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Stress> ;
-	skos:definition "from QUDT: Stress is a measure of the average amount of force exerted per unit area of a surface within a deformable body on which internal forces act. In other words, it is a measure of the intensity or internal distribution of the total internal forces acting within a deformable body across imaginary surfaces. These internal forces are produced between the particles in the body as a reaction to external forces applied on the body. Stress is defined as \\({\\rm{Stress}} = \\frac{F}{A}\\)."^^xsd:string ;
+	skos:definition "from QUDT: Stress is a measure of the average amount of force exerted per unit area of a surface within a deformable body on which internal forces act. In other words, it is a measure of the intensity or internal distribution of the total internal forces acting within a deformable body across imaginary surfaces. These internal forces are produced between the particles in the body as a reaction to external forces applied on the body. Stress is defined as (Stress = F/A)."^^xsd:string ;
 	skos:prefLabel "stress"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_pressure ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -9322,7 +9317,7 @@ gistd:_Aspect_thermal_conductivity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermalConductivity> ;
-	skos:definition "from QUDT: In physics, thermal conductivity, \\(k\\) (also denoted as \\(\\lambda\\)), is the property of a material's ability to conduct heat. It appears primarily in Fourier's Law for heat conduction and is the areic heat flow rate divided by temperature gradient."^^xsd:string ;
+	skos:definition "from QUDT: In physics, thermal conductivity, (k) (also denoted as (lambda)), is the property of a material's ability to conduct heat. It appears primarily in Fourier's Law for heat conduction and is the areic heat flow rate divided by temperature gradient."^^xsd:string ;
 	skos:prefLabel "thermal conductivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_thermal_conductivity ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9371,7 +9366,7 @@ gistd:_Aspect_thermal_diffusivity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Thermal_diffusivity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermalDiffusivity> ;
-	skos:definition "from QUDT: In heat transfer analysis, thermal diffusivity (usually denoted \\(\\alpha\\) but \\(a\\), \\(\\kappa\\),\\(k\\), and \\(D\\) are also used) is the thermal conductivity divided by density and specific heat capacity at constant pressure. The formula is: \\(\\alpha = {k \\over {\\rho c_p}}\\), where k is thermal conductivity (\\(W/(\\mu \\cdot K)\\)), \\(\\rho\\) is density (\\(kg/m^{3}\\)), and \\(c_p\\) is specific heat capacity (\\(\\frac{J}{(kg \\cdot K)}\\)) .The denominator \\(\\rho c_p\\), can be considered the volumetric heat capacity (\\(\\frac{J}{(m^{3} \\cdot K)}\\))."^^xsd:string ;
+	skos:definition "from QUDT: In heat transfer analysis, thermal diffusivity (usually denoted (alpha) but (a), (kappa),(k), and (D) are also used) is the thermal conductivity divided by density and specific heat capacity at constant pressure. The formula is: (alpha = {k over {rho c_p}}), where k is thermal conductivity ((W/(mu K))), (rho) is density ((kg/m^{3})), and (c_p) is specific heat capacity J/(kg K) .The denominator (rho c_p), can be considered the volumetric heat capacity ((J/(m^{3} K)}))."^^xsd:string ;
 	skos:prefLabel "thermal diffusivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_area_per_time ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9391,7 +9386,7 @@ gistd:_Aspect_thermal_energy
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Thermal_energy"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermalEnergy> ;
-	skos:definition 'from QUDT: "Thermal Energy} is the portion of the thermodynamic or internal energy of a system that is responsible for the temperature of the system. From a macroscopic thermodynamic description, the thermal energy of a system is given by its constant volume specific heat capacity C(T), a temperature coefficient also called thermal capacity, at any given absolute temperature (T): \\(U_{thermal} = C(T) \\cdot T\\).'^^xsd:string ;
+	skos:definition 'from QUDT: "Thermal Energy} is the portion of the thermodynamic or internal energy of a system that is responsible for the temperature of the system. From a macroscopic thermodynamic description, the thermal energy of a system is given by its constant volume specific heat capacity C(T), a temperature coefficient also called thermal capacity, at any given absolute temperature (T): (U_{thermal} = C(T) T).'^^xsd:string ;
 	skos:prefLabel "thermal energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_amount_of_heat ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9417,7 +9412,7 @@ gistd:_Aspect_thermal_insulance
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Thermal_insulation"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermalInsulance> ;
-	skos:definition "from QUDT: \\(\\textit{Thermal Insulance}\\) is the reduction of heat transfer (the transfer of thermal energy between objects of differing temperature) between objects in thermal contact or in range of radiative influence. In building technology, this quantity is often called \\(\\textit{Thermal Resistance}\\), with the symbol \\(R\\)."^^xsd:string ;
+	skos:definition "from QUDT: ({Thermal Insulance}) is the reduction of heat transfer (the transfer of thermal energy between objects of differing temperature) between objects in thermal contact or in range of radiative influence. In building technology, this quantity is often called ({Thermal Resistance}), with the symbol (R)."^^xsd:string ;
 	skos:prefLabel "thermal insulance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_thermal_insulance ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9430,7 +9425,7 @@ gistd:_Aspect_thermal_resistance
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermalResistance> ;
-	skos:definition "from QUDT: \\(\\textit{Thermal Resistance}\\) is a heat property and a measure of a temperature difference by which an object or material resists a heat flow (heat per time unit or thermal resistance). Thermal resistance is the reciprocal thermal conductance. the thermodynamic temperature difference divided by heat flow rate. Thermal resistance \\(R\\) has the units \\(\\frac{m^2 \\cdot K}{W}\\)."^^xsd:string ;
+	skos:definition "from QUDT: ({Thermal Resistance}) is a heat property and a measure of a temperature difference by which an object or material resists a heat flow (heat per time unit or thermal resistance). Thermal resistance is the reciprocal thermal conductance. the thermodynamic temperature difference divided by heat flow rate. Thermal resistance (R) has the units (m^2 K/W)."^^xsd:string ;
 	skos:prefLabel "thermal resistance"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_thermal_resistance ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9439,7 +9434,7 @@ gistd:_Aspect_thermal_resistance
 gistd:_Aspect_thermal_resistivity
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermalResistivity> ;
-	skos:definition "from QUDT: The reciprocal of thermal conductivity is thermal resistivity, measured in \\(kelvin-metres\\) per watt (\\(K \\cdot m/W\\))."^^xsd:string ;
+	skos:definition "from QUDT: The reciprocal of thermal conductivity is thermal resistivity, measured in (kelvin-metres) per watt ((K m/W))."^^xsd:string ;
 	skos:prefLabel "thermal resistivity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_thermal_resistivity ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9499,7 +9494,7 @@ gistd:_Aspect_thermodynamic_entropy
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermodynamicEntropy> ;
-	skos:definition "from QUDT: Thermodynamic Entropy is a measure of the unavailability of a system's energy to do work. It is a measure of the randomness of molecules in a system and is central to the second law of thermodynamics and the fundamental thermodynamic relation, which deal with physical processes and whether they occur spontaneously. The dimensions of entropy are energy divided by temperature, which is the same as the dimensions of Boltzmann's constant (\\(kB\\)) and heat capacity. The SI unit of entropy is \\(joule\\ per\\ kelvin\\). [Wikipedia]"^^xsd:string ;
+	skos:definition "from QUDT: Thermodynamic Entropy is a measure of the unavailability of a system's energy to do work. It is a measure of the randomness of molecules in a system and is central to the second law of thermodynamics and the fundamental thermodynamic relation, which deal with physical processes and whether they occur spontaneously. The dimensions of entropy are energy divided by temperature, which is the same as the dimensions of Boltzmann's constant ((kB)) and heat capacity. The SI unit of entropy is (joule per kelvin). [Wikipedia]"^^xsd:string ;
 	skos:prefLabel "thermodynamic entropy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_temperature ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9508,9 +9503,7 @@ gistd:_Aspect_thermodynamic_entropy
 gistd:_Aspect_thermodynamic_temperature
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/ThermodynamicTemperature> ;
-	skos:definition """from QUDT: Thermodynamic temperature is the absolute measure of temperature and is one of the principal parameters of thermodynamics.
-Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold.
-In thermodynamics, in a system of which the entropy is considered as an independent externally controlled variable, absolute, or thermodynamic temperature is defined as the derivative of the internal energy with respect to the entropy. This is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based."""^^xsd:string ;
+	skos:definition "from QUDT: Thermodynamic temperature is the absolute measure of temperature and is one of the principal parameters of thermodynamics. Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold.  In thermodynamics, in a system of which the entropy is considered as an independent externally controlled variable, absolute, or thermodynamic temperature is defined as the derivative of the internal energy with respect to the entropy. This is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based."^^xsd:string ;
 	skos:prefLabel "thermodynamic temperature"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_temperature ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -9594,7 +9587,7 @@ gistd:_Aspect_time_averaged_sound_intensity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Sound_intensity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/TimeAveragedSoundIntensity> ;
-	skos:definition "from QUDT: Sound intensity or acoustic intensity (\\(I\\)) is defined as the sound power \\(P_a\\) per unit area \\(A\\). The usual context is the noise measurement of sound intensity in the air at a listener's location as a sound energy quantity."^^xsd:string ;
+	skos:definition "from QUDT: Sound intensity or acoustic intensity ((I)) is defined as the sound power (P_a) per unit area (A). The usual context is the noise measurement of sound intensity in the air at a listener's location as a sound energy quantity."^^xsd:string ;
 	skos:prefLabel "time averaged sound intensity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_power_per_area ;
 	gist:isCategorizedBy gistd:_Discipline_acoustics ;
@@ -9643,12 +9636,10 @@ gistd:_Aspect_torque
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Torque> ;
-	skos:definition """from QUDT: In physics, a torque (\\(\\tau\\)) is a vector that measures the tendency of a force to rotate an object about some axis. The magnitude of a torque is defined as force times its lever arm. Just as a force is a push or a pull, a torque can be thought of as a twist. The SI unit for torque is newton meters (\\(N m\\)). In U.S. customary units, it is measured in foot pounds (ft lbf) (also known as \"pounds feet\").
-Mathematically, the torque on a particle (which has the position r in some reference frame) can be defined as the cross product: \\(τ = r x F\\)
-where,
+	skos:definition """from QUDT: In physics, a torque ((tau)) is a vector that measures the tendency of a force to rotate an object about some axis. The magnitude of a torque is defined as force times its lever arm. Just as a force is a push or a pull, a torque can be thought of as a twist. The SI unit for torque is newton meters ((N m)). In U.S. customary units, it is measured in foot pounds (ft lbf) (also known as \"pounds feet\").  Mathematically, the torque on a particle (which has the position r in some reference frame) can be defined as the cross product: (τ = r x F) where,
 r is the particle's position vector relative to the fulcrum
 F is the force acting on the particles,
-or, more generally, torque can be defined as the rate of change of angular momentum: \\(τ = dL/dt\\)
+or, more generally, torque can be defined as the rate of change of angular momentum: (τ = dL/dt)
 where,
 L is the angular momentum vector
 t stands for time."""^^xsd:string ;
@@ -9680,7 +9671,7 @@ gistd:_Aspect_total_angular_momentum
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/TotalAngularMomentum> ;
-	skos:definition 'from QUDT: "Total Angular Momentum" combines both the spin and orbital angular momentum of all particles and fields. In atomic and nuclear physics, orbital angular momentum is usually denoted by \\(l\\) or \\(L\\) instead of \\(\\Lambda\\). The magnitude of \\(J\\) is quantized so that \\(J^2 = \\hbar^2 j(j + 1)\\), where \\(j\\) is the total angular momentum quantum number.'^^xsd:string ;
+	skos:definition 'from QUDT: "Total Angular Momentum" combines both the spin and orbital angular momentum of all particles and fields. In atomic and nuclear physics, orbital angular momentum is usually denoted by (l) or (L) instead of (Lambda). The magnitude of (J) is quantized so that (J^2 = hbar^2 j(j + 1)), where (j) is the total angular momentum quantum number.'^^xsd:string ;
 	skos:prefLabel "total angular momentum"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_angular_momentum ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -9693,7 +9684,7 @@ gistd:_Aspect_total_angular_momentum_quantum_number
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/TotalAngularMomentumQuantumNumber> ;
-	skos:definition 'from QUDT: The "Total Angular Quantum Number" describes the magnitude of total angular momentum \\(J\\), where \\(j\\) refers to a specific particle and \\(J\\) is used for the whole system.'^^xsd:string ;
+	skos:definition 'from QUDT: The "Total Angular Quantum Number" describes the magnitude of total angular momentum (J), where (j) refers to a specific particle and (J) is used for the whole system.'^^xsd:string ;
 	skos:prefLabel "total angular momentum quantum number"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_quantum_number ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -9755,7 +9746,7 @@ gistd:_Aspect_total_ionization
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/TotalIonization> ;
-	skos:definition 'from QUDT: "Total Ionization" by a particle, total mean charge, divided by the elementary charge, \\(e\\), of all positive ions produced by an ionizing charged particle along its entire path and along the paths of any secondary charged particles.'^^xsd:string ;
+	skos:definition 'from QUDT: "Total Ionization" by a particle, total mean charge, divided by the elementary charge, (e), of all positive ions produced by an ionizing charged particle along its entire path and along the paths of any secondary charged particles.'^^xsd:string ;
 	skos:prefLabel "total ionization"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_atomic_physics ;
@@ -9794,7 +9785,7 @@ gistd:_Aspect_total_mass_stopping_power
 gistd:_Aspect_total_pressure
 	a gist:Aspect ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/TotalPressure> ;
-	skos:definition "from QUDT: The total pressure is the sum of the dynamic and static pressures, that is \\(P_0 = P + q\\)."^^xsd:string ;
+	skos:definition "from QUDT: The total pressure is the sum of the dynamic and static pressures, that is (P_0 = P + q)."^^xsd:string ;
 	skos:prefLabel "total pressure"^^xsd:string ;
 	gist:hasUnitGroup
 		gistd:_UnitGroup_fluid_pressure ,
@@ -9986,8 +9977,7 @@ gistd:_Aspect_voltage
 	a gist:Aspect ;
 	rdfs:seeAlso "https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Voltage> ;
-	skos:definition """from QUDT: \\(\\textit{Voltage}\\), also referred to as \\(\\textit{Electric Tension}\\), is the difference between electrical potentials of two points. For an electric field within a medium, \\(U_{ab} = - \\int_{r_a}^{r_b} E . {dr}\\), where \\(E\\) is electric field strength.
-For an irrotational electric field, the voltage is independent of the path between the two points \\(a\\) and \\(b\\)."""^^xsd:string ;
+	skos:definition "from QUDT: ({Voltage}), also referred to as ({Electric Tension}), is the difference between electrical potentials of two points. For an electric field within a medium, (U_{ab} = - int_{r_a}^{r_b} E . {dr}), where (E) is electric field strength. For an irrotational electric field, the voltage is independent of the path between the two points (a) and (b)."^^xsd:string ;
 	skos:prefLabel "voltage"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work_per_electric_charge ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -10076,7 +10066,7 @@ gistd:_Aspect_volume_strain
 		"https://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/VolumeStrain> ;
-	skos:definition "from QUDT: Volume, or volumetric, Strain, or dilatation (the relative variation of the volume) is the trace of the tensor \\(\\vartheta\\)."^^xsd:string ;
+	skos:definition "from QUDT: Volume, or volumetric, Strain, or dilatation (the relative variation of the volume) is the trace of the tensor (vartheta)."^^xsd:string ;
 	skos:prefLabel "volume strain"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_ratio ;
 	gist:isCategorizedBy gistd:_Discipline_mechanics ;
@@ -10116,7 +10106,7 @@ gistd:_Aspect_volumetric_heat_capacity
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Volumetric_heat_capacity"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/VolumetricHeatCapacity> ;
-	skos:definition "from QUDT: \\(\\textit{Volumetric Heat Capacity (VHC)}\\), also termed \\(\\textit{volume-specific heat capacity}\\), describes the ability of a given volume of a substance to store internal energy while undergoing a given temperature change, but without undergoing a phase transition. It is different from specific heat capacity in that the VHC is a \\(\\textit{per unit volume}\\) measure of the relationship between thermal energy and temperature of a material, while the specific heat is a \\(\\textit{per unit mass}\\) measure (or occasionally per molar quantity of the material)."^^xsd:string ;
+	skos:definition "from QUDT: ({Volumetric Heat Capacity (VHC)}), also termed ({volume-specific heat capacity}), describes the ability of a given volume of a substance to store internal energy while undergoing a given temperature change, but without undergoing a phase transition. It is different from specific heat capacity in that the VHC is a ({per unit volume}) measure of the relationship between thermal energy and temperature of a material, while the specific heat is a ({per unit mass}) measure (or occasionally per molar quantity of the material)."^^xsd:string ;
 	skos:prefLabel "volumetric heat capacity"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_volumetric_heat_capacity ;
 	gist:isCategorizedBy gistd:_Discipline_thermodynamics ;
@@ -10129,7 +10119,7 @@ gistd:_Aspect_volumic_electromagnetic_energy
 		"https://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI
 		;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/VolumicElectromagneticEnergy> ;
-	skos:definition "from QUDT: \\(\\textit{Volumic Electromagnetic Energy}\\), also known as the \\(\\textit{Electromagnetic Energy Density}\\), is the energy associated with an electromagnetic field, per unit volume of the field."^^xsd:string ;
+	skos:definition "from QUDT: ({Volumic Electromagnetic Energy}), also known as the ({Electromagnetic Energy Density}), is the energy associated with an electromagnetic field, per unit volume of the field."^^xsd:string ;
 	skos:prefLabel "volumic electromagnetic energy"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_volumic_electromagnetic_energy ;
 	gist:isCategorizedBy gistd:_Discipline_electricity_and_magnetism ;
@@ -10195,7 +10185,7 @@ gistd:_Aspect_wavelength
 	a gist:Aspect ;
 	rdfs:seeAlso "https://en.wikipedia.org/wiki/Wavelength"^^xsd:anyURI ;
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Wavelength> ;
-	skos:definition "from QUDT: For a monochromatic wave, \"wavelength\" is the distance between two successive points in a direction perpendicular to the wavefront where at a given instant the phase differs by \\(2\\pi\\). The wavelength of a sinusoidal wave is the spatial period of the wave-the distance over which the wave's shape repeats. The SI unit of wavelength is the meter."^^xsd:string ;
+	skos:definition "from QUDT: For a monochromatic wave, wavelength is the distance between two successive points in a direction perpendicular to the wavefront where at a given instant the phase differs by (2pi). The wavelength of a sinusoidal wave is the spatial period of the wave-the distance over which the wave's shape repeats. The SI unit of wavelength is the meter."^^xsd:string ;
 	skos:prefLabel "wavelength"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_distance ;
 	gist:isCategorizedBy
@@ -10289,7 +10279,7 @@ gistd:_Aspect_work
 	skos:closeMatch <http://qudt.org/vocab/quantitykind/Work> ;
 	skos:definition
 		"from QUDT: A force is said to do Work when it acts on a body so that there is a displacement of the point of application, however small, in the direction of the force. The concepts of work and energy are closely tied to the concept of force because an applied force can do work on an object and cause a change in energy. Energy is defined as the ability to do work. Work is done on an object when an applied force moves it through a distance. Kinetic energy is the energy of an object in motion. The net work is equal to the change in kinetic energy."^^xsd:string ,
-		"from QUDT: The net work is equal to the change in kinetic energy. This relationship is called the work-energy theorem: \\(Wnet = K. E._f - K. E._o \\), where \\(K. E._f\\) is the final kinetic energy and \\(K. E._o\\) is the original kinetic energy. Potential energy, also referred to as stored energy, is the ability of a system to do work due to its position or internal structure. Change in potential energy is equal to work. The potential energy equations can also be derived from the integral form of work, \\(\\Delta P. E. = W = \\int F \\cdot dx\\)."^^xsd:string
+		"from QUDT: The net work is equal to the change in kinetic energy. This relationship is called the work-energy theorem: (Wnet = K. E._f - K. E._o ), where (K. E._f) is the final kinetic energy and (K. E._o) is the original kinetic energy. Potential energy, also referred to as stored energy, is the ability of a system to do work due to its position or internal structure. Change in potential energy is equal to work. The potential energy equations can also be derived from the integral form of work, (Delta P. E. = W = int F dx)."^^xsd:string
 		;
 	skos:prefLabel "work"^^xsd:string ;
 	gist:hasUnitGroup gistd:_UnitGroup_energy_or_work ;
@@ -30825,7 +30815,7 @@ gistd:_UnitOfMeasure_pennyweight
 	a gist:UnitOfMeasure ;
 	skos:altLabel "pennyweight"^^xsd:string ;
 	skos:closeMatch <http://qudt.org/vocab/unit/Pennyweight> ;
-	skos:definition "from QUDT: non SI-conforming unit of mass which comes from the Anglo-American Troy or Apothecaries' Weight System of units according to NIST of 1 pwt = 1.555174 10^3 kg"^^xsd:string ;
+	skos:definition "from QUDT: non SI-conforming unit of mass which comes from the Anglo-American Troy or Apothecaries Weight System of units according to NIST of 1 pwt = 1.555174 10^3 kg"^^xsd:string ;
 	skos:prefLabel "pennyweight"^^xsd:string ;
 	skos:scopeNote "1 pennyweight = 0.001555174 x kilogram"^^xsd:string ;
 	gist:conversionFactor "0.001555174"^^xsd:decimal ;


### PR DESCRIPTION
No issue number, just a pull request.